### PR TITLE
Ballot representation as list

### DIFF
--- a/theories/Blacks_Rule.thy
+++ b/theories/Blacks_Rule.thy
@@ -23,4 +23,11 @@ subsection \<open>Definition\<close>
 fun blacks_rule :: "'a Electoral_Module" where
   "blacks_rule A p = (pairwise_majority_rule \<triangleright> borda_rule) A p"
 
+subsection \<open>Soundness\<close>
+
+theorem blacks_rule_sound: "electoral_module blacks_rule"
+  unfolding blacks_rule.simps
+  using pairwise_majority_rule_sound borda_rule_sound seq_comp_sound
+  by metis
+
 end

--- a/theories/Borda_Rule.thy
+++ b/theories/Borda_Rule.thy
@@ -25,9 +25,6 @@ subsection \<open>Definition\<close>
 fun borda_rule :: "'a Electoral_Module" where
   "borda_rule A p = elector borda A p"
 
-fun borda_rule_dr :: "'a Electoral_Module" where
-  "borda_rule_dr A p = (dr_rule (votewise_distance swap l_one) unanimity) A p"
-
 subsection \<open>Soundness\<close>
 
 theorem borda_rule_sound: "electoral_module borda_rule"

--- a/theories/Borda_Rule.thy
+++ b/theories/Borda_Rule.thy
@@ -25,5 +25,14 @@ subsection \<open>Definition\<close>
 fun borda_rule :: "'a Electoral_Module" where
   "borda_rule A p = elector borda A p"
 
+fun borda_rule_dr :: "'a Electoral_Module" where
+  "borda_rule_dr A p = (dr_rule (votewise_distance swap l_one) unanimity) A p"
+
+subsection \<open>Soundness\<close>
+
+theorem borda_rule_sound: "electoral_module borda_rule"
+  unfolding borda_rule.simps
+  using elector_sound borda_sound
+  by metis
 
 end

--- a/theories/Classic_Nanson_Rule.thy
+++ b/theories/Classic_Nanson_Rule.thy
@@ -25,4 +25,10 @@ fun classic_nanson_rule :: "'a Electoral_Module" where
   "classic_nanson_rule A p =
     ((leq_average_eliminator borda_score) \<circlearrowleft>\<^sub>\<exists>\<^sub>!\<^sub>d) A p"
 
+subsection \<open>Soundness\<close>
+
+theorem classic_nanson_rule_sound: "electoral_module classic_nanson_rule"
+  unfolding classic_nanson_rule.simps
+  by (simp add: loop_comp_sound)
+
 end

--- a/theories/Compositional_Structures/Basic_Modules/Borda_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Borda_Module.thy
@@ -28,4 +28,11 @@ fun borda_score :: "'a Evaluation_Function" where
 fun borda :: "'a Electoral_Module" where
   "borda A p = max_eliminator borda_score A p"
 
+subsection \<open>Soundness\<close>
+
+theorem borda_sound: "electoral_module borda"
+  unfolding borda.simps
+  using max_elim_sound
+  by metis
+
 end

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Aggregator.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Aggregator.thy
@@ -36,7 +36,7 @@ subsection \<open>Properties\<close>
 
 definition agg_commutative :: "'a Aggregator \<Rightarrow> bool" where
   "agg_commutative agg \<equiv>
-    aggregator agg \<and> (\<forall>A e1 e2 d1 d2 r1 r2.
+    aggregator agg \<and> (\<forall> A e1 e2 d1 d2 r1 r2.
       agg A (e1, r1, d1) (e2, r2, d2) = agg A (e2, r2, d2) (e1, r1, d1))"
 
 definition agg_conservative :: "'a Aggregator \<Rightarrow> bool" where

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Electoral_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Electoral_Module.thy
@@ -57,10 +57,12 @@ definition electoral_module :: " 'a Electoral_Module \<Rightarrow> bool" where
   "electoral_module m \<equiv> \<forall> A p. finite_profile A p \<longrightarrow> well_formed A (m A p)"
 
 lemma electoral_modI:
-  "((\<And> A p. \<lbrakk> finite_profile A p \<rbrakk> \<Longrightarrow> well_formed A (m A p)) \<Longrightarrow>
-       electoral_module m)"
+  fixes m :: "'a Electoral_Module"
+  assumes "\<And> A p. finite_profile A p \<Longrightarrow> well_formed A (m A p)"
+  shows "electoral_module m"
   unfolding electoral_module_def
-  by auto
+  using assms
+  by simp
 
 text \<open>
   The next three functions take an electoral module and turn it into a
@@ -167,99 +169,105 @@ definition mod_contains_result :: "'a Electoral_Module \<Rightarrow> 'a Electora
     (a \<in> reject m A p \<longrightarrow> a \<in> reject n A p) \<and>
     (a \<in> defer m A p \<longrightarrow> a \<in> defer n A p)"
 
-subsection \<open>Auxiliary Lemmata\<close>
+subsection \<open>Auxiliary Lemmas\<close>
 
 lemma combine_ele_rej_def:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a set" and
+    r :: "'a set" and
+    d :: "'a set"
   assumes
-    ele: "elect m A p = e" and
-    rej: "reject m A p = r" and
-    def: "defer m A p = d"
+    "elect m A p = e" and
+    "reject m A p = r" and
+    "defer m A p = d"
   shows "m A p = (e, r, d)"
-  using def ele rej
+  using assms
   by auto
 
 lemma par_comp_result_sound:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
-    mod_m: "electoral_module m" and
-    f_prof: "finite_profile A p"
+    "electoral_module m" and
+    "finite_profile A p"
   shows "well_formed A (m A p)"
-  using mod_m f_prof
+  using assms
   unfolding electoral_module_def
   by simp
 
 lemma result_presv_alts:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     e_mod: "electoral_module m" and
     f_prof: "finite_profile A p"
   shows "(elect m A p) \<union> (reject m A p) \<union> (defer m A p) = A"
 proof (safe)
-  fix x :: "'a"
-  assume elec_x: "x \<in> elect m A p"
-  have partit:
-    "\<forall> A p.
-      \<not> set_equals_partition (A::'a set) p \<or>
-        (\<exists> A' elec rej def. A = A' \<and> p = (elec, rej, def) \<and> elec \<union> rej \<union> def = A')"
+  fix a :: "'a"
+  assume elec_a: "a \<in> elect m A p"
+  have partit: "\<forall> p. set_equals_partition A p \<longrightarrow> (\<exists> E R D. p = (E, R, D) \<and> E \<union> R \<union> D = A)"
     by simp
-  from e_mod f_prof have set_partit:
-    "set_equals_partition A (m A p)"
+  have set_partit: "set_equals_partition A (m A p)"
+    using e_mod f_prof
     unfolding electoral_module_def
     by simp
-  thus "x \<in> A"
-    using UnI1 elec_x fstI set_partit partit
+  thus "a \<in> A"
+    using UnI1 elec_a fstI partit
     by (metis (no_types))
 next
-  fix x :: "'a"
-  assume rej_x: "x \<in> reject m A p"
-  have partit:
-    "\<forall> A p.
-      \<not> set_equals_partition (A::'a set) p \<or>
-        (\<exists> A' elec rej def. A = A' \<and> p = (elec, rej, def) \<and> elec \<union> rej \<union> def = A')"
+  fix a :: "'a"
+  assume rej_a: "a \<in> reject m A p"
+  have partit: "\<forall> p. set_equals_partition A p \<longrightarrow> (\<exists> E R D. p = (E, R, D) \<and> E \<union> R \<union> D = A)"
     by simp
-  from e_mod f_prof have set_partit:
-    "set_equals_partition A (m A p)"
+  have "set_equals_partition A (m A p)"
+    using e_mod f_prof
     unfolding electoral_module_def
     by simp
-  thus "x \<in> A"
-    using UnI1 rej_x fstI set_partit partit
+  thus "a \<in> A"
+    using UnI1 rej_a fstI partit
           sndI subsetD sup_ge2
     by metis
 next
-  fix x :: "'a"
-  assume def_x: "x \<in> defer m A p"
-  have partit:
-    "\<forall> A p.
-      \<not> set_equals_partition (A::'a set) p \<or>
-        (\<exists> A' elec rej def. A = A' \<and> p = (elec, rej, def) \<and> elec \<union> rej \<union> def = A')"
+  fix a :: "'a"
+  assume def_a: "a \<in> defer m A p"
+  have partit: "\<forall> p. set_equals_partition A p \<longrightarrow> (\<exists> E R D. p = (E, R, D) \<and> E \<union> R \<union> D = A)"
     by simp
-  from e_mod f_prof have set_partit:
-    "set_equals_partition A (m A p)"
+  have "set_equals_partition A (m A p)"
+    using e_mod f_prof
     unfolding electoral_module_def
     by simp
-  thus "x \<in> A"
-    using def_x set_partit partit sndI subsetD sup_ge2
+  thus "a \<in> A"
+    using def_a partit sndI subsetD sup_ge2
     by metis
 next
-  fix x :: "'a"
+  fix a :: "'a"
   assume
-    x_in_A: "x \<in> A" and
-    not_def_x: "x \<notin> defer m A p" and
-    not_rej_x: "x \<notin> reject m A p"
-  have partit:
-    "\<forall> A p.
-      \<not> set_equals_partition (A::'a set) p \<or>
-        (\<exists> A' elec rej def. A = A' \<and> p = (elec, rej, def) \<and> elec \<union> rej \<union> def = A')"
+    a_in_A: "a \<in> A" and
+    not_def_a: "a \<notin> defer m A p" and
+    not_rej_a: "a \<notin> reject m A p"
+  have partit: "\<forall> p. set_equals_partition A p \<longrightarrow> (\<exists> E R D. p = (E, R, D) \<and> E \<union> R \<union> D = A)"
     by simp
-  from e_mod f_prof have set_partit:
-    "set_equals_partition A (m A p)"
+  from e_mod f_prof
+  have "set_equals_partition A (m A p)"
     unfolding electoral_module_def
     by simp
-  show "x \<in> elect m A p"
-    using x_in_A not_def_x not_rej_x fst_conv partit
-          set_partit snd_conv Un_iff
+  thus "a \<in> elect m A p"
+    using a_in_A not_def_a not_rej_a fst_conv partit snd_conv Un_iff
     by metis
 qed
 
 lemma result_disj:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module: "electoral_module m" and
     profile: "finite_profile A p"
@@ -268,64 +276,32 @@ lemma result_disj:
         (elect m A p) \<inter> (defer m A p) = {} \<and>
         (reject m A p) \<inter> (defer m A p) = {}"
 proof (safe, simp_all)
-  fix x :: "'a"
+  fix a :: "'a"
   assume
-    elect_x: "x \<in> elect m A p" and
-    reject_x: "x \<in> reject m A p"
-  have partit:
-    "\<forall> A p.
-      \<not> set_equals_partition (A::'a set) p \<or>
-        (\<exists> B C D E. A = B \<and> p = (C, D, E) \<and> C \<union> D \<union> E = B)"
-    by simp
-  from module profile have set_partit:
-    "set_equals_partition A (m A p)"
-    unfolding electoral_module_def
-    by simp
-  from profile have prof_p:
-    "finite A \<and> profile A p"
-    by simp
-  from module prof_p have wf_A_m:
-    "well_formed A (m A p)"
+    elect_a: "a \<in> elect m A p" and
+    reject_a: "a \<in> reject m A p"
+  have "well_formed A (m A p)"
+    using module profile
     unfolding electoral_module_def
     by metis
-  show False
-    using prod.exhaust_sel DiffE UnCI elect_x reject_x
-          module profile result_imp_rej wf_A_m
-          prof_p set_partit partit
+  thus False
+    using prod.exhaust_sel DiffE UnCI elect_a reject_a result_imp_rej
     by (metis (no_types))
 next
-  fix x :: "'a"
+  fix a :: "'a"
   assume
-    elect_x: "x \<in> elect m A p" and
-    defer_x: "x \<in> defer m A p"
-  have partit:
-    "\<forall> A p.
-      \<not> set_equals_partition (A::'a set) p \<or>
-        (\<exists> B C D E. A = B \<and> p = (C, D, E) \<and> C \<union> D \<union> E = B)"
-    by simp
+    elect_a: "a \<in> elect m A p" and
+    defer_a: "a \<in> defer m A p"
   have disj:
-    "\<forall> p. \<not> disjoint3 p \<or>
-      (\<exists> B C D. p = (B::'a set, C, D) \<and>
-        B \<inter> C = {} \<and> B \<inter> D = {} \<and> C \<inter> D = {})"
+    "\<forall> p. disjoint3 p \<longrightarrow> (\<exists> B C D. p = (B, C, D) \<and> B \<inter> C = {} \<and> B \<inter> D = {} \<and> C \<inter> D = {})"
     by simp
-  from profile have prof_p:
-    "finite A \<and> profile A p"
-    by simp
-  from module prof_p have wf_A_m:
-    "well_formed A (m A p)"
+  have "well_formed A (m A p)"
+    using module profile
     unfolding electoral_module_def
     by metis
-  hence wf_A_m_0:
-    "disjoint3 (m A p) \<and> set_equals_partition A (m A p)"
+  hence "disjoint3 (m A p)"
     by simp
-  hence disj3:
-    "disjoint3 (m A p)"
-    by simp
-  have set_partit:
-    "set_equals_partition A (m A p)"
-    using wf_A_m_0
-    by simp
-  from disj3 obtain
+  then obtain
     elec :: "'a Result \<Rightarrow> 'a set" and
     rej :: "'a Result \<Rightarrow> 'a set" and
     def :: "'a Result \<Rightarrow> 'a set"
@@ -335,75 +311,76 @@ next
         elec (m A p) \<inter> rej (m A p) = {} \<and>
         elec (m A p) \<inter> def (m A p) = {} \<and>
         rej (m A p) \<inter> def (m A p) = {}"
-    using elect_x defer_x disj
+    using elect_a defer_a disj
     by metis
   hence "((elect m A p) \<inter> (reject m A p) = {}) \<and>
           ((elect m A p) \<inter> (defer m A p) = {}) \<and>
           ((reject m A p) \<inter> (defer m A p) = {})"
-    using disj3 eq_snd_iff fstI
+    using eq_snd_iff fstI
     by metis
   thus False
-    using elect_x defer_x module profile wf_A_m prof_p
-          set_partit partit disjoint_iff_not_equal
+    using elect_a defer_a disjoint_iff_not_equal
     by (metis (no_types))
 next
-  fix x :: "'a"
+  fix a :: "'a"
   assume
-    reject_x: "x \<in> reject m A p" and
-    defer_x: "x \<in> defer m A p"
-  have partit:
-    "\<forall> A p.
-      \<not> set_equals_partition (A::'a set) p \<or>
-        (\<exists> B C D E. A = B \<and> p = (C, D, E) \<and> C \<union> D \<union> E = B)"
-    by simp
-  from module profile have set_partit:
-    "set_equals_partition A (m A p)"
+    reject_a: "a \<in> reject m A p" and
+    defer_a: "a \<in> defer m A p"
+  have "well_formed A (m A p)"
+    using module profile
     unfolding electoral_module_def
     by simp
-  from profile have prof_p:
-    "finite A \<and> profile A p"
-    by simp
-  from module prof_p have wf_A_m:
-    "well_formed A (m A p)"
-    unfolding electoral_module_def
-    by simp
-  show False
-    using prod.exhaust_sel DiffE UnCI reject_x defer_x
-          module profile result_imp_rej wf_A_m
-          prof_p set_partit partit
+  thus False
+    using prod.exhaust_sel DiffE UnCI reject_a defer_a result_imp_rej
     by (metis (no_types))
 qed
 
 lemma elect_in_alts:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
-    e_mod: "electoral_module m" and
-    f_prof: "finite_profile A p"
+    "electoral_module m" and
+    "finite_profile A p"
   shows "elect m A p \<subseteq> A"
-  using le_supI1 e_mod f_prof result_presv_alts sup_ge1
+  using le_supI1 assms result_presv_alts sup_ge1
   by metis
 
 lemma reject_in_alts:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
-    e_mod: "electoral_module m" and
-    f_prof: "finite_profile A p"
+    "electoral_module m" and
+    "finite_profile A p"
   shows "reject m A p \<subseteq> A"
-  using le_supI1 e_mod f_prof result_presv_alts sup_ge2
+  using le_supI1 assms result_presv_alts sup_ge2
   by fastforce
 
 lemma defer_in_alts:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
-    e_mod: "electoral_module m" and
-    f_prof: "finite_profile A p"
+    "electoral_module m" and
+    "finite_profile A p"
   shows "defer m A p \<subseteq> A"
-  using e_mod f_prof result_presv_alts
+  using assms result_presv_alts
   by auto
 
 lemma def_presv_fin_prof:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
-    module:  "electoral_module m" and
-    f_prof: "finite_profile A p"
+    "electoral_module m" and
+    "finite_profile A p"
   shows "let new_A = defer m A p in finite_profile new_A (limit_profile new_A p)"
-  using defer_in_alts infinite_super limit_profile_sound module f_prof
+  using defer_in_alts infinite_super limit_profile_sound assms
   by metis
 
 text \<open>
@@ -412,32 +389,38 @@ text \<open>
 \<close>
 
 lemma upper_card_bounds_for_result:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
-    e_mod: "electoral_module m" and
-    f_prof: "finite_profile A p"
+    "electoral_module m" and
+    "finite_profile A p"
   shows
     "card (elect m A p) \<le> card A \<and>
       card (reject m A p) \<le> card A \<and>
       card (defer m A p) \<le> card A "
-  using e_mod f_prof
+  using assms
   by (simp add: card_mono defer_in_alts elect_in_alts reject_in_alts)
 
 lemma reject_not_elec_or_def:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     e_mod: "electoral_module m" and
     f_prof: "finite_profile A p"
   shows "reject m A p = A - (elect m A p) - (defer m A p)"
 proof -
-  from e_mod f_prof
-  have 0: "well_formed A (m A p)"
+  have "well_formed A (m A p)"
+    using e_mod f_prof
     unfolding electoral_module_def
     by simp
-  with e_mod f_prof
-    have "(elect m A p) \<union> (reject m A p) \<union> (defer m A p) = A"
-      using result_presv_alts
-      by simp
-    moreover from 0
-    have
+  hence "(elect m A p) \<union> (reject m A p) \<union> (defer m A p) = A"
+    using e_mod f_prof result_presv_alts
+    by simp
+  moreover have
       "(elect m A p) \<inter> (reject m A p) = {} \<and>
           (reject m A p) \<inter> (defer m A p) = {}"
     using e_mod f_prof result_disj
@@ -447,23 +430,26 @@ proof -
 qed
 
 lemma elec_and_def_not_rej:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     e_mod: "electoral_module m" and
     f_prof: "finite_profile A p"
   shows "elect m A p \<union> defer m A p = A - (reject m A p)"
 proof -
   from e_mod f_prof
-  have 0: "well_formed A (m A p)"
+  have "well_formed A (m A p)"
     unfolding electoral_module_def
     by simp
   hence
     "disjoint3 (m A p) \<and> set_equals_partition A (m A p)"
     by simp
-  with e_mod f_prof
   have "(elect m A p) \<union> (reject m A p) \<union> (defer m A p) = A"
     using e_mod f_prof result_presv_alts
     by blast
-  moreover from 0 have
+  moreover have
     "(elect m A p) \<inter> (reject m A p) = {} \<and>
         (reject m A p) \<inter> (defer m A p) = {}"
     using e_mod f_prof result_disj
@@ -473,19 +459,23 @@ proof -
 qed
 
 lemma defer_not_elec_or_rej:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     e_mod: "electoral_module m" and
     f_prof: "finite_profile A p"
   shows "defer m A p = A - (elect m A p) - (reject m A p)"
 proof -
   from e_mod f_prof
-  have 0: "well_formed A (m A p)"
+  have "well_formed A (m A p)"
     unfolding electoral_module_def
     by simp
   hence "(elect m A p) \<union> (reject m A p) \<union> (defer m A p) = A"
     using e_mod f_prof result_presv_alts
     by simp
-  moreover from 0 have
+  moreover have
     "(elect m A p) \<inter> (defer m A p) = {} \<and>
         (reject m A p) \<inter> (defer m A p) = {}"
     using e_mod f_prof result_disj
@@ -495,46 +485,55 @@ proof -
 qed
 
 lemma electoral_mod_defer_elem:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
-    e_mod: "electoral_module m" and
-    f_prof: "finite_profile A p" and
-    alternative: "x \<in> A" and
-    not_elected: "x \<notin> elect m A p" and
-    not_rejected: "x \<notin> reject m A p"
-  shows "x \<in> defer m A p"
-  using DiffI e_mod f_prof alternative
-        not_elected not_rejected
-        reject_not_elec_or_def
+    "electoral_module m" and
+    "finite_profile A p" and
+    "a \<in> A" and
+    "a \<notin> elect m A p" and
+    "a \<notin> reject m A p"
+  shows "a \<in> defer m A p"
+  using DiffI assms reject_not_elec_or_def
   by metis
 
 lemma mod_contains_result_comm:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes "mod_contains_result m n A p a"
   shows "mod_contains_result n m A p a"
 proof (unfold mod_contains_result_def, safe)
   from assms
   show "electoral_module n"
     unfolding mod_contains_result_def
-    by simp
+    by safe
 next
   from assms
   show "electoral_module m"
     unfolding mod_contains_result_def
-    by simp
+    by safe
 next
   from assms
   show "finite A"
     unfolding mod_contains_result_def
-    by simp
+    by safe
 next
   from assms
   show "profile A p"
     unfolding mod_contains_result_def
-    by simp
+    by safe
 next
   from assms
   show "a \<in> A"
     unfolding mod_contains_result_def
-    by simp
+    by safe
 next
   assume "a \<in> elect n A p"
   thus "a \<in> elect m A p"
@@ -556,111 +555,131 @@ next
 qed
 
 lemma not_rej_imp_elec_or_def:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
-    e_mod: "electoral_module m" and
-    f_prof: "finite_profile A p" and
-    alternative: "x \<in> A" and
-    not_rejected: "x \<notin> reject m A p"
-  shows "x \<in> elect m A p \<or> x \<in> defer m A p"
-  using alternative electoral_mod_defer_elem
-        e_mod not_rejected f_prof
+    "electoral_module m" and
+    "finite_profile A p" and
+    "a \<in> A" and
+    "a \<notin> reject m A p"
+  shows "a \<in> elect m A p \<or> a \<in> defer m A p"
+  using assms electoral_mod_defer_elem
   by metis
 
 lemma single_elim_imp_red_def_set:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
-    eliminating: "eliminates 1 m" and
-    leftover_alternatives: "card A > 1" and
-    f_prof: "finite_profile A p"
+    "eliminates 1 m" and
+    "card A > 1" and
+    "finite_profile A p"
   shows "defer m A p \<subset> A"
-  using Diff_eq_empty_iff Diff_subset card_eq_0_iff defer_in_alts
-        eliminates_def eliminating eq_iff leftover_alternatives
-        not_one_le_zero f_prof psubsetI reject_not_elec_or_def
+  using Diff_eq_empty_iff Diff_subset card_eq_0_iff defer_in_alts eliminates_def
+        eq_iff not_one_le_zero psubsetI reject_not_elec_or_def assms
   by metis
 
 lemma eq_alts_in_profs_imp_eq_results:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile"
   assumes
-    eq: "\<forall> a \<in> A. prof_contains_result m A p p' a" and
-    input: "electoral_module m \<and> finite_profile A p \<and> finite_profile A p'"
-  shows "m A p = m A p'"
+    eq: "\<forall> a \<in> A. prof_contains_result m A p q a" and
+    mod_m: "electoral_module m" and
+    fin_prof_p: "finite_profile A p" and
+    fin_prof_q: "finite_profile A q"
+  shows "m A p = m A q"
 proof -
-  have "\<forall> a \<in> elect m A p. a \<in> elect m A p'"
-    using elect_in_alts eq prof_contains_result_def input in_mono
+  have elected_in_A: "elect m A q \<subseteq> A"
+    using elect_in_alts mod_m fin_prof_q
     by metis
-  moreover have "\<forall> a \<in> elect m A p'. a \<in> elect m A p"
-  proof -
-    fix a :: 'a
-    have "\<forall> A A'. (A'::'a set) \<inter> A = {} \<or> A' \<noteq> {}"
+  have rejected_in_A: "reject m A q \<subseteq> A"
+    using reject_in_alts mod_m fin_prof_q
+    by metis
+  have deferred_in_A: "defer m A q \<subseteq> A"
+    using defer_in_alts mod_m fin_prof_q
+    by metis
+  have "\<forall> a \<in> elect m A p. a \<in> elect m A q"
+    using elect_in_alts eq prof_contains_result_def mod_m fin_prof_p in_mono
+    by metis
+  moreover have "\<forall> a \<in> elect m A q. a \<in> elect m A p"
+  proof
+    fix a :: "'a"
+    assume q_elect_a: "a \<in> elect m A q"
+    hence a_in_A: "a \<in> A"
+      using elected_in_A
       by blast
-    moreover have elect_diff: "elect m A p' - A = {}"
-      using Diff_eq_empty_iff elect_in_alts input
+    have a_not_deferred_q: "a \<notin> defer m A q"
+      using q_elect_a fin_prof_q mod_m result_disj
+      by blast
+    have a_not_rejected_q: "a \<notin> reject m A q"
+      using disjoint_iff_not_equal fin_prof_q mod_m q_elect_a result_disj
       by metis
-    moreover have def_elec_disj: "defer m A p' \<inter> elect m A p' = {}"
-      using disjoint_iff_not_equal input result_disj
-      by (metis (no_types))
-    moreover have rej_elec_disj: "reject m A p' \<inter> elect m A p' = {}"
-      using disjoint_iff_not_equal input result_disj
-      by (metis (no_types))
-    ultimately have
-      "(\<exists> A'. A' \<inter> elect m A p' = {} \<and> a \<in> A') \<or>
-          a \<notin> elect m A p' \<or> a \<in> elect m A p"
-      using DiffI electoral_mod_defer_elem eq
-      unfolding prof_contains_result_def
-      by (metis (no_types))
-    from elect_diff def_elec_disj rej_elec_disj
-    show ?thesis
-      using Diff_iff Int_iff empty_iff eq not_rej_imp_elec_or_def
-      unfolding prof_contains_result_def
+    show "a \<in> elect m A p"
+      using a_in_A electoral_mod_defer_elem eq a_not_deferred_q a_not_rejected_q
+            prof_contains_result_def
       by metis
   qed
-  moreover have
-    "\<forall> a \<in> reject m A p. a \<in> reject m A p'"
-    using reject_in_alts eq prof_contains_result_def input in_mono
+  moreover have "\<forall> a \<in> reject m A p. a \<in> reject m A q"
+    using reject_in_alts eq prof_contains_result_def mod_m fin_prof_p
     by fastforce
-  moreover have
-    "\<forall> a \<in> reject m A p'. a \<in> reject m A p"
-  proof -
-    {
-      fix a' :: 'a
-      have rej_set:
-        "\<forall> f. electoral_module f \<longrightarrow> reject f A p' \<subseteq> A"
-        using input reject_in_alts
-        by metis
-      have rej_def_disj:
-        "\<forall> f. electoral_module f \<longrightarrow> reject f A p' \<inter> defer f A p' = {}"
-        using input result_disj
-        by metis
-      have "electoral_module m \<and> profile A p \<and> finite_profile A p'"
-        using input
-        by blast
-      hence
-        "elect m A p' \<inter> reject m A p' = {} \<and> elect m A p' \<inter> defer m A p' = {} \<and>
-          reject m A p' \<inter> defer m A p' = {}"
-        by (simp add: result_disj)
-      hence
-        "a' \<in> elect m A p' \<longrightarrow> a' \<notin> reject m A p' \<or> a' \<in> reject m A p"
-        using disjoint_iff_not_equal
-        by metis
-      hence "a' \<notin> reject m A p' \<or> a' \<in> reject m A p"
-        using rej_def_disj rej_set electoral_mod_defer_elem eq input
-        unfolding prof_contains_result_def
-        by fastforce
-    }
-    thus ?thesis
+  moreover have "\<forall> a \<in> reject m A q. a \<in> reject m A p"
+  proof
+    fix a :: 'a
+    assume q_rejects_a: "a \<in> reject m A q"
+    hence a_in_A: "a \<in> A"
+      using rejected_in_A
+      by blast
+    have a_not_deferred_q: "a \<notin> defer m A q"
+      using q_rejects_a fin_prof_q mod_m result_disj
+      by blast
+    have a_not_elected_q: "a \<notin> elect m A q"
+      using disjoint_iff_not_equal fin_prof_q mod_m q_rejects_a result_disj
+      by metis
+    show "a \<in> reject m A p"
+      using a_in_A electoral_mod_defer_elem eq a_not_deferred_q a_not_elected_q
+            prof_contains_result_def
       by metis
   qed
-  moreover have "\<forall> a \<in> defer m A p. a \<in> defer m A p'"
-    using defer_in_alts eq prof_contains_result_def input in_mono
+  moreover have "\<forall> a \<in> defer m A p. a \<in> defer m A q"
+    using defer_in_alts eq prof_contains_result_def mod_m fin_prof_p
     by fastforce
-  moreover have "\<forall> a \<in> defer m A p'. a \<in> defer m A p"
-    using calculation defer_not_elec_or_rej
-          input subsetI subset_antisym
-    by metis
+  moreover have "\<forall> a \<in> defer m A q. a \<in> defer m A p"
+  proof
+    fix a :: "'a"
+    assume q_defers_a: "a \<in> defer m A q"
+    hence a_in_A: "a \<in> A"
+      using deferred_in_A
+      by blast
+    have a_not_elected_q: "a \<notin> elect m A q"
+      using q_defers_a fin_prof_q mod_m result_disj
+      by blast
+    have a_not_rejected_q: "a \<notin> reject m A q"
+      using disjoint_iff_not_equal fin_prof_q mod_m q_defers_a result_disj
+      by metis
+    show "a \<in> defer m A p"
+      using a_in_A electoral_mod_defer_elem eq a_not_elected_q a_not_rejected_q
+            prof_contains_result_def
+      by metis
+  qed
   ultimately show ?thesis
     using prod.collapse subsetI subset_antisym
-    by metis
+    by (metis (no_types))
 qed
 
 lemma eq_def_and_elect_imp_eq:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile"
   assumes
     mod_m: "electoral_module m" and
     mod_n: "electoral_module n" and
@@ -670,46 +689,15 @@ lemma eq_def_and_elect_imp_eq:
     def_eq: "defer m A p = defer n A q"
   shows "m A p = n A q"
 proof -
-  have disj_m:
-    "disjoint3 (m A p)"
-    using mod_m fin_p
-    unfolding electoral_module_def
-    by auto
-  have disj_n:
-    "disjoint3 (n A q)"
-    using mod_n fin_q
-    unfolding electoral_module_def
-    by auto
-  have set_partit_m:
-    "set_equals_partition A ((elect m A p), (reject m A p), (defer m A p))"
-    using mod_m fin_p
-    unfolding electoral_module_def
-    by auto
-  moreover have
-    "disjoint3 ((elect m A p),(reject m A p),(defer m A p))"
-    using disj_m prod.collapse
-    by metis
-  have set_partit_n:
-    "set_equals_partition A ((elect n A q), (reject n A q), (defer n A q))"
-    using mod_n fin_q
-    unfolding electoral_module_def
-    by auto
-  moreover have
-    "disjoint3 ((elect n A q),(reject n A q),(defer n A q))"
-    using disj_n prod.collapse
-    by metis
-  have reject_p:
-    "reject m A p = A - ((elect m A p) \<union> (defer m A p))"
+  have "reject m A p = A - ((elect m A p) \<union> (defer m A p))"
     using mod_m fin_p combine_ele_rej_def result_imp_rej
     unfolding electoral_module_def
     by metis
-  have reject_q:
-    "reject n A q = A - ((elect n A q) \<union> (defer n A q))"
+  moreover have "reject n A q = A - ((elect n A q) \<union> (defer n A q))"
     using mod_n fin_q combine_ele_rej_def result_imp_rej
     unfolding electoral_module_def
     by metis
-  from reject_p reject_q
-  show ?thesis
+  ultimately show ?thesis
     using elec_eq def_eq prod_eqI
     by metis
 qed
@@ -740,36 +728,41 @@ definition electing :: "'a Electoral_Module \<Rightarrow> bool" where
       (\<forall> A p. (A \<noteq> {} \<and> finite_profile A p) \<longrightarrow> elect m A p \<noteq> {})"
 
 lemma electing_for_only_alt:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     one_alt: "card A = 1" and
     electing: "electing m" and
     f_prof: "finite_profile A p"
   shows "elect m A p = A"
 proof (safe)
-  fix x :: "'a"
-  assume electX: "x \<in> elect m A p"
-  have
-    "\<not> electoral_module m \<or> elect m A p \<subseteq> A"
+  fix a :: "'a"
+  assume elect_a: "a \<in> elect m A p"
+  have "electoral_module m \<longrightarrow> elect m A p \<subseteq> A"
     using elect_in_alts f_prof
     by (simp add: elect_in_alts)
-  with electing have "elect m A p \<subseteq> A"
+  hence "elect m A p \<subseteq> A"
+    using electing
     unfolding electing_def
     by metis
-  with electX show "x \<in> A"
-    by auto
+  thus "a \<in> A"
+    using elect_a
+    by blast
 next
-  fix x :: "'a"
-  assume "x \<in> A"
-  with electing f_prof one_alt
-  show "x \<in> elect m A p"
+  fix a :: "'a"
+  assume "a \<in> A"
+  with electing
+  show "a \<in> elect m A p"
     unfolding electing_def
-    using One_nat_def Suc_leI card_seteq
-          card_gt_0_iff elect_in_alts
-          infinite_super
+    using f_prof one_alt One_nat_def Suc_leI card_seteq
+          card_gt_0_iff elect_in_alts infinite_super
     by metis
 qed
 
 theorem electing_imp_non_blocking:
+  fixes m :: "'a Electoral_Module"
   assumes "electing m"
   shows "non_blocking m"
 proof (unfold non_blocking_def, safe)
@@ -781,28 +774,19 @@ next
   fix
     A :: "'a set" and
     p :: "'a Profile" and
-    x :: "'a"
+    a :: "'a"
   assume
-    finA: "finite A" and
-    profA: "profile A p" and
-    rejA: "reject m A p = A" and
-    xInA: "x \<in> A"
-  from assms have
-    "electoral_module m \<and>
-      (\<forall> A rs. A = {} \<or> infinite A \<or>
-        \<not> profile A rs \<or> elect m A rs \<noteq> {})"
+    fin_A: "finite A" and
+    prof_A: "profile A p" and
+    rej_A: "reject m A p = A" and
+    a_in_A: "a \<in> A"
+  have "electoral_module m \<and> (\<forall> A q. A \<noteq> {} \<and> finite A \<and> profile A q \<longrightarrow> elect m A q \<noteq> {})"
+    using assms
     unfolding electing_def
     by metis
-  hence f1: "A = {}"
-    using Diff_cancel Un_empty
-          elec_and_def_not_rej
-          finA profA rejA
+  thus "a \<in> {}"
+    using Diff_cancel Un_empty elec_and_def_not_rej fin_A prof_A rej_A a_in_A
     by (metis (no_types))
-  from  xInA
-  have "x \<in> A"
-    by metis
-  with f1 show "x \<in> {}"
-    by metis
 qed
 
 subsection \<open>Properties\<close>
@@ -817,6 +801,10 @@ definition non_electing :: "'a Electoral_Module \<Rightarrow> bool" where
     electoral_module m \<and> (\<forall> A p. finite_profile A p \<longrightarrow> elect m A p = {})"
 
 lemma single_elim_decr_def_card:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     rejecting: "rejects 1 m" and
     not_empty: "A \<noteq> {}" and
@@ -824,27 +812,27 @@ lemma single_elim_decr_def_card:
     f_prof: "finite_profile A p"
   shows "card (defer m A p) = card A - 1"
 proof -
-  have "rejects 1 m"
-    using One_nat_def rejecting
+  have no_elect: "electoral_module m \<and> (\<forall> A q. finite A \<and> profile A q \<longrightarrow> elect m A q = {})"
+    using non_electing_def f_prof not_empty non_electing
+    by (metis (no_types))
+  have rejected_in_A: "reject m A p \<subseteq> A"
+    using no_elect f_prof reject_in_alts
     by metis
-  moreover have
-    "electoral_module m \<and>
-      (\<forall> A rs. infinite A \<or> \<not> profile A rs \<or> elect m A rs = {})"
-    using non_electing
-    unfolding non_electing_def
-    by metis
-  moreover from this have
-    "reject m A p \<subseteq> A"
-    using f_prof reject_in_alts
-    by metis
-  ultimately show ?thesis
-    using f_prof not_empty
+  have "A = A - elect m A p"
+    using no_elect f_prof
+    by blast
+  thus ?thesis
+    using f_prof rejected_in_A rejecting not_empty
     by (simp add: Suc_leI card_Diff_subset card_gt_0_iff
                   defer_not_elec_or_rej finite_subset
                   rejects_def)
 qed
 
-lemma single_elim_decr_def_card2:
+lemma single_elim_decr_def_card_2:
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     eliminating: "eliminates 1 m" and
     not_empty: "card A > 1" and
@@ -852,36 +840,18 @@ lemma single_elim_decr_def_card2:
     f_prof: "finite_profile A p"
   shows "card (defer m A p) = card A - 1"
 proof -
-  have
-    "\<forall> f. (non_electing f \<or>
-            (\<exists> A rs. ({}::'a set) \<noteq> elect f A rs \<and> profile A rs \<and> finite A) \<or>
-            \<not> electoral_module f) \<and>
-          ((\<forall> A rs. {} = elect f A rs \<or> \<not> profile A rs \<or> infinite A) \<and>
-            electoral_module f \<or> \<not> non_electing f)"
-    using non_electing_def
-    by metis
-  moreover from this have
-    "electoral_module m \<and>
-      (\<forall> A rs. infinite A \<or> \<not> profile A rs \<or> elect m A rs = {})"
-    using non_electing
+  have no_elect: "electoral_module m \<and> (\<forall> A q. finite A \<and> profile A q \<longrightarrow> elect m A q = {})"
+    using non_electing_def f_prof not_empty non_electing
     by (metis (no_types))
-  moreover from this have
-    "reject m A p \<subseteq> A"
-    using f_prof reject_in_alts
+  have rejected_in_A: "reject m A p \<subseteq> A"
+    using no_elect f_prof reject_in_alts
     by metis
-  moreover have "1 < card A"
-    using not_empty
-    by presburger
-  moreover have "eliminates 1 m"
-    using One_nat_def eliminating
-    by presburger
-  moreover have "eliminates 1 m"
-    using eliminating
-    by force
-  ultimately show ?thesis
-    using f_prof
-    by (simp add: card_Diff_subset defer_not_elec_or_rej
-                  eliminates_def finite_subset)
+  have "A = A - elect m A p"
+    using no_elect f_prof
+    by blast
+  thus ?thesis
+    using f_prof rejected_in_A eliminating not_empty
+    by (simp add: card_Diff_subset defer_not_elec_or_rej eliminates_def finite_subset)
 qed
 
 text \<open>
@@ -904,13 +874,13 @@ text \<open>
 definition decrementing :: "'a Electoral_Module \<Rightarrow> bool" where
   "decrementing m \<equiv>
     electoral_module m \<and> (
-      \<forall> A p . finite_profile A p \<longrightarrow>
+      \<forall> A p. finite_profile A p \<longrightarrow>
           (card A > 1 \<longrightarrow> card (reject m A p) \<ge> 1))"
 
 definition defer_condorcet_consistency :: "'a Electoral_Module \<Rightarrow> bool" where
   "defer_condorcet_consistency m \<equiv>
     electoral_module m \<and>
-    (\<forall> A p w. condorcet_winner A p w \<and> finite A \<longrightarrow>
+    (\<forall> A p a. condorcet_winner A p a \<and> finite A \<longrightarrow>
       (m A p =
         ({},
         A - (defer m A p),
@@ -919,11 +889,11 @@ definition defer_condorcet_consistency :: "'a Electoral_Module \<Rightarrow> boo
 definition condorcet_compatibility :: "'a Electoral_Module \<Rightarrow> bool" where
   "condorcet_compatibility m \<equiv>
     electoral_module m \<and>
-    (\<forall> A p w. condorcet_winner A p w \<and> finite A \<longrightarrow>
-      (w \<notin> reject m A p \<and>
-        (\<forall> l. \<not>condorcet_winner A p l \<longrightarrow> l \<notin> elect m A p) \<and>
-          (w \<in> elect m A p \<longrightarrow>
-            (\<forall> l. \<not>condorcet_winner A p l \<longrightarrow> l \<in> reject m A p))))"
+    (\<forall> A p a. condorcet_winner A p a \<and> finite A \<longrightarrow>
+      (a \<notin> reject m A p \<and>
+        (\<forall> b. \<not>condorcet_winner A p b \<longrightarrow> b \<notin> elect m A p) \<and>
+          (a \<in> elect m A p \<longrightarrow>
+            (\<forall> b. \<not>condorcet_winner A p b \<longrightarrow> b \<in> reject m A p))))"
 
 text \<open>
   An electoral module is defer-monotone iff,
@@ -933,8 +903,8 @@ text \<open>
 definition defer_monotonicity :: "'a Electoral_Module \<Rightarrow> bool" where
   "defer_monotonicity m \<equiv>
     electoral_module m \<and>
-      (\<forall> A p q w.
-          (finite A \<and> w \<in> defer m A p \<and> lifted A p q w) \<longrightarrow> w \<in> defer m A q)"
+      (\<forall> A p q a.
+          (finite A \<and> a \<in> defer m A p \<and> lifted A p q a) \<longrightarrow> a \<in> defer m A q)"
 
 text \<open>
   An electoral module is defer-lift-invariant iff
@@ -957,12 +927,12 @@ definition disjoint_compatibility :: "'a Electoral_Module \<Rightarrow>
                                          'a Electoral_Module \<Rightarrow> bool" where
   "disjoint_compatibility m n \<equiv>
     electoral_module m \<and> electoral_module n \<and>
-        (\<forall> S. finite S \<longrightarrow>
-          (\<exists> A \<subseteq> S.
-            (\<forall> a \<in> A. indep_of_alt m S a \<and>
-              (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject m S p)) \<and>
-            (\<forall> a \<in> S - A. indep_of_alt n S a \<and>
-              (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject n S p))))"
+        (\<forall> A. finite A \<longrightarrow>
+          (\<exists> B \<subseteq> A.
+            (\<forall> a \<in> B. indep_of_alt m A a \<and>
+              (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject m A p)) \<and>
+            (\<forall> a \<in> A - B. indep_of_alt n A a \<and>
+              (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject n A p))))"
 
 text \<open>
   Lifting an elected alternative a from an invariant-monotone
@@ -991,48 +961,56 @@ definition defer_invariant_monotonicity :: "'a Electoral_Module \<Rightarrow> bo
 subsection \<open>Inference Rules\<close>
 
 lemma ccomp_and_dd_imp_def_only_winner:
-  assumes ccomp: "condorcet_compatibility m" and
-          dd: "defer_deciding m" and
-          winner: "condorcet_winner A p w"
-  shows "defer m A p = {w}"
+  fixes
+    m :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
+  assumes
+    ccomp: "condorcet_compatibility m" and
+    dd: "defer_deciding m" and
+    winner: "condorcet_winner A p a"
+  shows "defer m A p = {a}"
 proof (rule ccontr)
-  assume not_w: "defer m A p \<noteq> {w}"
-  from dd have def_1:
+  assume not_w: "defer m A p \<noteq> {a}"
+  from dd
+  have def_1:
     "defers 1 m"
     unfolding defer_deciding_def
     by metis
   hence c_win:
-    "finite_profile A p \<and>  w \<in> A \<and> (\<forall>x \<in> A - {w} . wins w p x)"
+    "finite_profile A p \<and>  a \<in> A \<and> (\<forall> b \<in> A - {a}. wins a p b)"
     using winner
     by simp
   hence "card (defer m A p) = 1"
     using Suc_leI card_gt_0_iff def_1 equals0D
     unfolding One_nat_def defers_def
     by metis
-  hence 0: "\<exists> x \<in> A . defer m A p = {x}"
+  hence 0: "\<exists> b \<in> A. defer m A p = {b}"
     using card_1_singletonE dd defer_in_alts insert_subset c_win
     unfolding defer_deciding_def
     by metis
-  with not_w have "\<exists> l \<in> A . l \<noteq> w \<and> defer m A p = {l}"
+  with not_w
+  have "\<exists> b \<in> A. b \<noteq> a \<and> defer m A p = {b}"
     by metis
-  hence not_in_defer: "w \<notin> defer m A p"
+  hence not_in_defer: "a \<notin> defer m A p"
     by auto
   have "non_electing m"
     using dd
     unfolding defer_deciding_def
     by simp
-  hence not_in_elect: "w \<notin> elect m A p"
+  hence not_in_elect: "a \<notin> elect m A p"
     using c_win equals0D
     unfolding non_electing_def
     by simp
   from not_in_defer not_in_elect
   have one_side:
-    "w \<in> reject m A p"
+    "a \<in> reject m A p"
     using ccomp c_win electoral_mod_defer_elem
     unfolding condorcet_compatibility_def
     by metis
   from ccomp
-  have other_side: "w \<notin> reject m A p"
+  have other_side: "a \<notin> reject m A p"
     using c_win winner
     unfolding condorcet_compatibility_def
     by simp
@@ -1041,6 +1019,7 @@ proof (rule ccontr)
 qed
 
 theorem ccomp_and_dd_imp_dcc[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes
     ccomp: "condorcet_compatibility m" and
     dd: "defer_deciding m"
@@ -1054,73 +1033,75 @@ next
   fix
     A :: "'a set" and
     p :: "'a Profile" and
-    w :: "'a"
+    a :: "'a"
   assume
     prof_A: "profile A p" and
-    w_in_A: "w \<in> A" and
+    a_in_A: "a \<in> A" and
     finiteness: "finite A" and
-    assm: "\<forall> x \<in> A - {w}.
-          card {i. i < length p \<and> (w, x) \<in> (p!i)} <
-            card {i. i < length p \<and> (x, w) \<in> (p!i)}"
-  have winner: "condorcet_winner A p w"
-    using assm finiteness prof_A w_in_A
+    c_winner: "\<forall> b \<in> A - {a}.
+                 card {i. i < length p \<and> (a, b) \<in> (p!i)} <
+                   card {i. i < length p \<and> (b, a) \<in> (p!i)}"
+  hence winner: "condorcet_winner A p a"
     by simp
   hence
     "m A p =
       ({},
         A - defer m A p,
-        {d \<in> A. condorcet_winner A p d})"
+        {c \<in> A. condorcet_winner A p c})"
   proof -
-    from dd have 0: "elect m A p = {}"
+    from dd
+    have 0: "elect m A p = {}"
       using winner
       unfolding defer_deciding_def non_electing_def
       by simp
-    from dd ccomp have 1: "defer m A p = {w}"
+    from dd ccomp
+    have 1: "defer m A p = {a}"
       using ccomp_and_dd_imp_def_only_winner winner
       by simp
-    from 0 1 have 2: "reject m A p = A - defer m A p"
+    from 0 1
+    have 2: "reject m A p = A - defer m A p"
       using Diff_empty dd reject_not_elec_or_def winner
       unfolding defer_deciding_def
       by fastforce
-    from 0 1 2 have 3: "m A p = ({}, A - defer m A p, {w})"
+    from 0 1 2
+    have 3: "m A p = ({}, A - defer m A p, {a})"
       using combine_ele_rej_def
       by metis
-    have "{w} = {d \<in> A. condorcet_winner A p d}"
-      using cond_winner_unique3 winner
+    have "{a} = {c \<in> A. condorcet_winner A p c}"
+      using cond_winner_unique_3 winner
       by metis
     thus ?thesis
       using 3
-      by auto
+      by simp
   qed
   hence
     "m A p =
       ({},
         A - defer m A p,
-        {d \<in> A. \<forall> x \<in> A - {d}. wins d p x})"
+        {c \<in> A. \<forall> b \<in> A - {c}. wins c p b})"
     using finiteness prof_A winner Collect_cong
-    by auto
-  hence
-    "m A p =
-        ({},
-          A - defer m A p,
-          {d \<in> A. \<forall> x \<in> A - {d}.
-            prefer_count p x d < prefer_count p d x})"
     by simp
   hence
     "m A p =
         ({},
           A - defer m A p,
-          {d \<in> A. \<forall> x \<in> A - {d}.
-            card {i. i < length p \<and> (let r = (p!i) in (d \<preceq>\<^sub>r x))} <
-                card {i. i < length p \<and> (let r = (p!i) in (x \<preceq>\<^sub>r d))}})"
+          {c \<in> A. \<forall> b \<in> A - {c}. prefer_count p b c < prefer_count p c b})"
+    by simp
+  hence
+    "m A p =
+        ({},
+          A - defer m A p,
+          {c \<in> A. \<forall> b \<in> A - {c}.
+            card {i. i < length p \<and> (let r = (p!i) in (c \<preceq>\<^sub>r b))} <
+                card {i. i < length p \<and> (let r = (p!i) in (b \<preceq>\<^sub>r c))}})"
     by simp
   thus
     "m A p =
         ({},
           A - defer m A p,
-          {d \<in> A. \<forall> x \<in> A - {d}.
-            card {i. i < length p \<and> (d, x) \<in> (p!i)} <
-              card {i. i < length p \<and> (x, d) \<in> (p!i)}})"
+          {c \<in> A. \<forall> b \<in> A - {c}.
+            card {i. i < length p \<and> (c, b) \<in> (p!i)} <
+              card {i. i < length p \<and> (b, c) \<in> (p!i)}})"
     by simp
 qed
 
@@ -1129,6 +1110,9 @@ text \<open>
 \<close>
 
 theorem disj_compat_comm[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes "disjoint_compatibility m n"
   shows "disjoint_compatibility n m"
 proof (unfold disjoint_compatibility_def, safe)
@@ -1142,39 +1126,39 @@ next
     unfolding disjoint_compatibility_def
     by simp
 next
-  fix S :: "'a set"
-  assume fin_S: "finite S"
-  obtain A where
+  fix A :: "'a set"
+  assume fin_S: "finite A"
+  obtain B where
     old_A:
-      "(A \<subseteq> S \<and>
-        (\<forall> a \<in> A. indep_of_alt m S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject m S p)) \<and>
-        (\<forall> a \<in> S - A. indep_of_alt n S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject n S p)))"
+      "(B \<subseteq> A \<and>
+        (\<forall> a \<in> B. indep_of_alt m A a \<and>
+          (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject m A p)) \<and>
+        (\<forall> a \<in> A - B. indep_of_alt n A a \<and>
+          (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject n A p)))"
     using assms fin_S
     unfolding disjoint_compatibility_def
     by metis
   hence
-    "(\<exists> A \<subseteq> S.
-      (\<forall> a \<in> S - A. indep_of_alt n S a \<and>
-        (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject n S p)) \<and>
-      (\<forall> a \<in> A. indep_of_alt m S a \<and>
-        (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject m S p)))"
+    "(\<exists> B \<subseteq> A.
+      (\<forall> a \<in> A - B. indep_of_alt n A a \<and>
+        (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject n A p)) \<and>
+      (\<forall> a \<in> B. indep_of_alt m A a \<and>
+        (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject m A p)))"
     by auto
   hence
-    "(\<exists> A \<subseteq> S.
-      (\<forall> a \<in> S - A. indep_of_alt n S a \<and>
-        (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject n S p)) \<and>
-      (\<forall> a \<in> S - (S - A). indep_of_alt m S a \<and>
-        (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject m S p)))"
+    "(\<exists> B \<subseteq> A.
+      (\<forall> a \<in> A - B. indep_of_alt n A a \<and>
+        (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject n A p)) \<and>
+      (\<forall> a \<in> A - (A - B). indep_of_alt m A a \<and>
+        (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject m A p)))"
     using double_diff order_refl
     by metis
   thus
-    "(\<exists> A \<subseteq> S.
-        (\<forall> a \<in> A. indep_of_alt n S a \<and>
-          (\<forall>p. finite_profile S p \<longrightarrow> a \<in> reject n S p)) \<and>
-        (\<forall> a \<in> S - A. indep_of_alt m S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject m S p)))"
+    "(\<exists> B \<subseteq> A.
+        (\<forall> a \<in> B. indep_of_alt n A a \<and>
+          (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject n A p)) \<and>
+        (\<forall> a \<in> A - B. indep_of_alt m A a \<and>
+          (\<forall> p. finite_profile A p \<longrightarrow> a \<in> reject m A p)))"
     by fastforce
 qed
 
@@ -1184,6 +1168,7 @@ text \<open>
 \<close>
 
 theorem dl_inv_imp_def_mono[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes "defer_lift_invariance m"
   shows "defer_monotonicity m"
   using assms
@@ -1197,18 +1182,19 @@ subsubsection \<open>Condorcet Consistency\<close>
 definition condorcet_consistency :: "'a Electoral_Module \<Rightarrow> bool" where
   "condorcet_consistency m \<equiv>
     electoral_module m \<and>
-    (\<forall> A p w. condorcet_winner A p w \<longrightarrow>
+    (\<forall> A p a. condorcet_winner A p a \<longrightarrow>
       (m A p =
         ({e \<in> A. condorcet_winner A p e},
           A - (elect m A p),
           {})))"
 
 lemma condorcet_consistency2:
-  "condorcet_consistency m \<longleftrightarrow>
-      electoral_module m \<and>
-        (\<forall> A p w. condorcet_winner A p w \<longrightarrow>
-            (m A p =
-              ({w}, A - (elect m A p), {})))"
+  fixes m :: "'a Electoral_Module"
+  shows "condorcet_consistency m =
+           (electoral_module m \<and>
+              (\<forall> A p a. condorcet_winner A p a \<longrightarrow>
+                  (m A p =
+                    ({a}, A - (elect m A p), {}))))"
 proof (safe)
   assume "condorcet_consistency m"
   thus "electoral_module m"
@@ -1218,37 +1204,37 @@ next
   fix
     A :: "'a set" and
     p :: "'a Profile" and
-    w :: "'a"
+    a :: "'a"
   assume
-    cc: "condorcet_consistency m" and
-    cwin: "condorcet_winner A p w"
-  show
-    "m A p = ({w}, A - elect m A p, {})"
-    using cond_winner_unique3 cc cwin
+    "condorcet_consistency m" and
+    "condorcet_winner A p a"
+  thus
+    "m A p = ({a}, A - elect m A p, {})"
+    using cond_winner_unique_3
     unfolding condorcet_consistency_def
     by (metis (mono_tags, lifting))
 next
   assume
     e_mod: "electoral_module m" and
     cwin:
-    "\<forall> A p w. condorcet_winner A p w \<longrightarrow>
-      m A p = ({w}, A - elect m A p, {})"
+    "\<forall> A p a. condorcet_winner A p a \<longrightarrow>
+      m A p = ({a}, A - elect m A p, {})"
   have
     "\<forall> f. condorcet_consistency f =
       (electoral_module f \<and>
-        (\<forall> A rs a. \<not> condorcet_winner A rs (a::'a) \<or>
-          f A rs = ({a \<in> A. condorcet_winner A rs a},
-                    A - elect f A rs, {})))"
+        (\<forall> A p a. condorcet_winner A p a \<longrightarrow>
+          f A p = ({a \<in> A. condorcet_winner A p a},
+                    A - elect f A p, {})))"
     unfolding condorcet_consistency_def
     by blast
   moreover have
-    "\<forall> A rs a. \<not> condorcet_winner A rs (a::'a) \<or>
-        {a \<in> A. condorcet_winner A rs a} = {a}"
-    using cond_winner_unique3
+    "\<forall> A p a. condorcet_winner A p (a::'a) \<longrightarrow>
+        {b \<in> A. condorcet_winner A p b} = {a}"
+    using cond_winner_unique_3
     by (metis (full_types))
   ultimately show "condorcet_consistency m"
     unfolding condorcet_consistency_def
-    using cond_winner_unique3 e_mod cwin
+    using cond_winner_unique_3 e_mod cwin
     by presburger
 qed
 
@@ -1262,8 +1248,8 @@ text \<open>
 definition monotonicity :: "'a Electoral_Module \<Rightarrow> bool" where
   "monotonicity m \<equiv>
     electoral_module m \<and>
-      (\<forall> A p q w.
-          (finite A \<and> w \<in> elect m A p \<and> lifted A p q w) \<longrightarrow> w \<in> elect m A q)"
+      (\<forall> A p q a.
+          (finite A \<and> a \<in> elect m A p \<and> lifted A p q a) \<longrightarrow> a \<in> elect m A q)"
 
 subsubsection \<open>Homogeneity\<close>
 

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Elimination_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Elimination_Module.thy
@@ -69,7 +69,12 @@ fun leq_average_eliminator :: "'a Evaluation_Function \<Rightarrow>
 
 subsection \<open>Soundness\<close>
 
-lemma elim_mod_sound[simp]: "electoral_module (elimination_module e t r)"
+lemma elim_mod_sound[simp]:
+  fixes
+    e :: "'a Evaluation_Function" and
+    t :: "Threshold_Value" and
+    r :: "Threshold_Relation"
+  shows "electoral_module (elimination_module e t r)"
 proof (unfold electoral_module_def, safe)
   fix
     A :: "'a set" and
@@ -80,7 +85,11 @@ proof (unfold electoral_module_def, safe)
     by simp
 qed
 
-lemma less_elim_sound[simp]: "electoral_module (less_eliminator e t)"
+lemma less_elim_sound[simp]:
+  fixes
+    e :: "'a Evaluation_Function" and
+    t :: "Threshold_Value"
+  shows "electoral_module (less_eliminator e t)"
 proof (unfold electoral_module_def, safe, simp)
   fix
     A :: "'a set" and
@@ -91,7 +100,11 @@ proof (unfold electoral_module_def, safe, simp)
     by safe
 qed
 
-lemma leq_elim_sound[simp]: "electoral_module (leq_eliminator e t)"
+lemma leq_elim_sound[simp]:
+  fixes
+    e :: "'a Evaluation_Function" and
+    t :: "Threshold_Value"
+  shows "electoral_module (leq_eliminator e t)"
 proof (unfold electoral_module_def, safe, simp)
   fix
     A :: "'a set" and
@@ -102,7 +115,9 @@ proof (unfold electoral_module_def, safe, simp)
     by safe
 qed
 
-lemma max_elim_sound[simp]: "electoral_module (max_eliminator e)"
+lemma max_elim_sound[simp]:
+  fixes e :: "'a Evaluation_Function"
+  shows "electoral_module (max_eliminator e)"
 proof (unfold electoral_module_def, safe, simp)
   fix
     A :: "'a set" and
@@ -113,48 +128,65 @@ proof (unfold electoral_module_def, safe, simp)
     by safe
 qed
 
-lemma min_elim_sound[simp]: "electoral_module (min_eliminator e)"
+lemma min_elim_sound[simp]:
+  fixes e :: "'a Evaluation_Function"
+  shows "electoral_module (min_eliminator e)"
 proof (unfold electoral_module_def, safe, simp)
   fix
     A :: "'a set" and
     p :: "'a Profile"
   show
-    "{a \<in> A. e a A p \<le> Min {e x A p |x. x \<in> A}} \<noteq> A \<longrightarrow>
-      {a \<in> A. e a A p \<le> Min {e x A p |x. x \<in> A}} \<union> A = A"
+    "{a \<in> A. e a A p \<le> Min {e x A p | x. x \<in> A}} \<noteq> A \<longrightarrow>
+      {a \<in> A. e a A p \<le> Min {e x A p | x. x \<in> A}} \<union> A = A"
     by safe
 qed
 
-lemma less_avg_elim_sound[simp]: "electoral_module (less_average_eliminator e)"
+lemma less_avg_elim_sound[simp]:
+  fixes e :: "'a Evaluation_Function"
+  shows "electoral_module (less_average_eliminator e)"
 proof (unfold electoral_module_def, safe, simp)
   fix
     A :: "'a set" and
     p :: "'a Profile"
   show
-    "{a \<in> A. e a A p < (\<Sum>x\<in>A. e x A p) div card A} \<noteq> A \<longrightarrow>
-      {a \<in> A. e a A p < (\<Sum>x\<in>A. e x A p) div card A} \<union> A = A"
+    "{a \<in> A. e a A p < (\<Sum> x \<in> A. e x A p) div card A} \<noteq> A \<longrightarrow>
+      {a \<in> A. e a A p < (\<Sum> x \<in> A. e x A p) div card A} \<union> A = A"
     by safe
 qed
 
-lemma leq_avg_elim_sound[simp]: "electoral_module (leq_average_eliminator e)"
+lemma leq_avg_elim_sound[simp]:
+  fixes e :: "'a Evaluation_Function"
+  shows "electoral_module (leq_average_eliminator e)"
 proof (unfold electoral_module_def, safe, simp)
   fix
     A :: "'a set" and
     p :: "'a Profile"
   show
-    "{a \<in> A. e a A p \<le> (\<Sum>x\<in>A. e x A p) div card A} \<noteq> A \<longrightarrow>
-      {a \<in> A. e a A p \<le> (\<Sum>x\<in>A. e x A p) div card A} \<union> A = A"
+    "{a \<in> A. e a A p \<le> (\<Sum> x \<in> A. e x A p) div card A} \<noteq> A \<longrightarrow>
+      {a \<in> A. e a A p \<le> (\<Sum> x \<in> A. e x A p) div card A} \<union> A = A"
     by safe
 qed
 
 subsection \<open>Non-Electing\<close>
 
 lemma elim_mod_non_electing:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function" and
+    t :: "Threshold_Value" and
+    r :: "Threshold_Relation"
   assumes profile: "finite_profile A p"
-  shows "non_electing (elimination_module e t r )"
+  shows "non_electing (elimination_module e t r)"
   unfolding non_electing_def
   by simp
 
 lemma less_elim_non_electing:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function" and
+    t :: "Threshold_Value"
   assumes profile: "finite_profile A p"
   shows "non_electing (less_eliminator e t)"
   using elim_mod_non_electing profile less_elim_sound
@@ -162,24 +194,41 @@ lemma less_elim_non_electing:
   by simp
 
 lemma leq_elim_non_electing:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function" and
+    t :: "Threshold_Value"
   assumes profile: "finite_profile A p"
   shows "non_electing (leq_eliminator e t)"
   unfolding non_electing_def
   by simp
 
 lemma max_elim_non_electing:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function"
   assumes profile: "finite_profile A p"
   shows "non_electing (max_eliminator e)"
   unfolding non_electing_def
   by simp
 
 lemma min_elim_non_electing:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function"
   assumes profile: "finite_profile A p"
   shows "non_electing (min_eliminator e)"
   unfolding non_electing_def
   by simp
 
 lemma less_avg_elim_non_electing:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function"
   assumes profile: "finite_profile A p"
   shows "non_electing (less_average_eliminator e)"
 proof (unfold non_electing_def, safe)
@@ -187,13 +236,13 @@ proof (unfold non_electing_def, safe)
     by simp
 next
   fix
-    A :: "'b set" and
-    p :: "'b Profile" and
-    x :: "'b"
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assume
     fin_A: "finite A" and
     prof_p: "profile A p" and
-    elect_x: "x \<in> elect (less_average_eliminator e) A p"
+    elect_a: "a \<in> elect (less_average_eliminator e) A p"
   hence fin_prof: "finite_profile A p"
     by metis
   have "non_electing (less_average_eliminator e)"
@@ -203,12 +252,16 @@ next
     using fin_prof
     unfolding non_electing_def
     by metis
-  thus "x \<in> {}"
-    using elect_x
+  thus "a \<in> {}"
+    using elect_a
     by metis
 qed
 
 lemma leq_avg_elim_non_electing:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function"
   assumes profile: "finite_profile A p"
   shows "non_electing (leq_average_eliminator e)"
 proof (unfold non_electing_def, safe)
@@ -216,24 +269,22 @@ proof (unfold non_electing_def, safe)
     by simp
 next
   fix
-    A :: "'b set" and
-    p :: "'b Profile" and
-    x :: "'b"
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assume
     fin_A: "finite A" and
     prof_p: "profile A p" and
-    elect_x: "x \<in> elect (leq_average_eliminator e) A p"
-  hence fin_prof: "finite_profile A p"
-    by metis
+    elect_a: "a \<in> elect (leq_average_eliminator e) A p"
   have "non_electing (leq_average_eliminator e)"
     unfolding non_electing_def
     by simp
   hence "{} = elect (leq_average_eliminator e) A p"
-    using fin_prof
+    using fin_A prof_p
     unfolding non_electing_def
     by metis
-  thus "x \<in> {}"
-    using elect_x
+  thus "a \<in> {}"
+    using elect_a
     by metis
 qed
 
@@ -245,6 +296,10 @@ text \<open>
 \<close>
 
 theorem cr_eval_imp_ccomp_max_elim[simp]:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function"
   assumes
     profile: "finite_profile A p" and
     rating: "condorcet_rating e"
@@ -254,68 +309,71 @@ proof (unfold condorcet_compatibility_def, safe)
     by simp
 next
   fix
-    A :: "'b set" and
-    p :: "'b Profile" and
-    w :: "'b"
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assume
-    c_win: "condorcet_winner A p w" and
-    rej_w: "w \<in> reject (max_eliminator e) A p"
-  have "e w A p = Max {e a A p | a. a \<in> A}"
+    c_win: "condorcet_winner A p a" and
+    rej_a: "a \<in> reject (max_eliminator e) A p"
+  have "e a A p = Max {e b A p | b. b \<in> A}"
     using c_win cond_winner_imp_max_eval_val rating
     by fastforce
-  hence "w \<notin> reject (max_eliminator e) A p"
+  hence "a \<notin> reject (max_eliminator e) A p"
     by simp
   thus "False"
-    using rej_w
+    using rej_a
     by linarith
 next
   fix
-    A :: "'b set" and
-    p :: "'b Profile" and
-    l :: "'b"
-  assume elect_l: "l \<in> elect (max_eliminator e) A p"
-  have "l \<notin> elect (max_eliminator e) A p"
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
+  assume elect_a: "a \<in> elect (max_eliminator e) A p"
+  have "a \<notin> elect (max_eliminator e) A p"
     by simp
   thus False
-    using elect_l
+    using elect_a
     by linarith
 next
   fix
-    A :: "'b set" and
-    p :: "'b Profile" and
-    w :: "'b" and
-    l :: "'b"
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a" and
+    a' :: "'a"
   assume
-    "condorcet_winner A p w" and
-    "w \<in> elect (max_eliminator e) A p"
-  thus "l \<in> reject (max_eliminator e) A p"
+    "condorcet_winner A p a" and
+    "a \<in> elect (max_eliminator e) A p"
+  thus "a' \<in> reject (max_eliminator e) A p"
     using profile rating condorcet_winner.elims(2)
           empty_iff max_elim_non_electing
     unfolding non_electing_def
     by metis
 qed
 
-lemma cr_eval_imp_dcc_max_elim_helper1:
+lemma cr_eval_imp_dcc_max_elim_helper:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    e :: "'a Evaluation_Function" and
+    a :: "'a"
   assumes
     f_prof: "finite_profile A p" and
     rating: "condorcet_rating e" and
-    winner: "condorcet_winner A p w"
-  shows "elimination_set e (Max {e x A p | x. x \<in> A}) (<) A p = A - {w}"
+    winner: "condorcet_winner A p a"
+  shows "elimination_set e (Max {e b A p | b. b \<in> A}) (<) A p = A - {a}"
 proof (safe, simp_all, safe)
-  assume
-    "e w A p < Max {e x A p |x. x \<in> A}"
+  assume "e a A p < Max {e b A p | b. b \<in> A}"
   thus False
     using cond_winner_imp_max_eval_val
           rating winner f_prof
     by fastforce
 next
-  fix x :: "'a"
+  fix a' :: "'a"
   assume
-    x_in_A: "x \<in> A" and
-    not_max: "\<not> e x A p < Max {e y A p |y. y \<in> A}"
-  show "x = w"
-    using non_cond_winner_not_max_eval x_in_A
-          rating winner f_prof not_max
+    "a' \<in> A" and
+    "\<not> e a' A p < Max {e b A p | b. b \<in> A}"
+  thus "a' = a"
+    using non_cond_winner_not_max_eval rating winner f_prof
     by (metis (mono_tags, lifting))
 qed
 
@@ -325,29 +383,30 @@ text \<open>
 \<close>
 
 theorem cr_eval_imp_dcc_max_elim[simp]:
+  fixes e :: "'a Evaluation_Function"
   assumes rating: "condorcet_rating e"
   shows "defer_condorcet_consistency (max_eliminator e)"
 proof (unfold defer_condorcet_consistency_def, safe, simp)
   fix
     A :: "'a set" and
     p :: "'a Profile" and
-    w :: "'a"
+    a :: "'a"
   assume
-    winner: "condorcet_winner A p w" and
+    winner: "condorcet_winner A p a" and
     finite: "finite A"
   hence profile: "finite_profile A p"
     by simp
-  let ?trsh = "(Max {e y A p | y. y \<in> A})"
+  let ?trsh = "(Max {e b A p | b. b \<in> A})"
   show
     "max_eliminator e A p =
       ({},
         A - defer (max_eliminator e) A p,
-        {a \<in> A. condorcet_winner A p a})"
+        {b \<in> A. condorcet_winner A p b})"
   proof (cases "elimination_set e (?trsh) (<) A p \<noteq> A")
     case True
     from profile rating winner
-    have 0: "(elimination_set e ?trsh (<) A p) = A - {w}"
-      using cr_eval_imp_dcc_max_elim_helper1
+    have 0: "(elimination_set e ?trsh (<) A p) = A - {a}"
+      using cr_eval_imp_dcc_max_elim_helper
       by (metis (mono_tags, lifting))
     have
       "max_eliminator e A p =
@@ -356,25 +415,25 @@ proof (unfold defer_condorcet_consistency_def, safe, simp)
           A - (elimination_set e ?trsh (<) A p))"
       using True
       by simp
-    also have "... = ({}, A - {w}, {w})"
+    also have "... = ({}, A - {a}, {a})"
       using 0 winner
       by auto
-    also have "... = ({},A - defer (max_eliminator e) A p, {w})"
+    also have "... = ({},A - defer (max_eliminator e) A p, {a})"
       using calculation
       by simp
     also have
       "... =
         ({},
           A - defer (max_eliminator e) A p,
-          {d \<in> A. condorcet_winner A p d})"
-      using cond_winner_unique3 winner Collect_cong
+          {b \<in> A. condorcet_winner A p b})"
+      using cond_winner_unique_3 winner Collect_cong
       by (metis (no_types, lifting))
     finally show ?thesis
       using finite winner
       by metis
   next
     case False
-    have "?trsh = e w A p"
+    have "?trsh = e a A p"
       using rating winner
       by (simp add: cond_winner_imp_max_eval_val)
     thus ?thesis

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Evaluation_Function.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Evaluation_Function.thy
@@ -18,7 +18,7 @@ text \<open>
 
 subsection \<open>Definition\<close>
 
-type_synonym 'a Evaluation_Function = "'a  \<Rightarrow> 'a set \<Rightarrow> 'a Profile \<Rightarrow> nat"
+type_synonym 'a Evaluation_Function = "'a \<Rightarrow> 'a set \<Rightarrow> 'a Profile \<Rightarrow> nat"
 
 subsection \<open>Property\<close>
 
@@ -40,15 +40,20 @@ text \<open>
 \<close>
 
 theorem cond_winner_imp_max_eval_val:
+  fixes
+    e :: "'a Evaluation_Function" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
     rating: "condorcet_rating e" and
     f_prof: "finite_profile A p" and
-    winner: "condorcet_winner A p w"
-  shows "e w A p = Max {e a A p | a. a \<in> A}"
+    winner: "condorcet_winner A p a"
+  shows "e a A p = Max {e b A p | b. b \<in> A}"
 proof -
-  let ?set = "{e a A p | a. a \<in> A}" and
-      ?eMax = "Max {e a A p | a. a \<in> A}" and
-      ?eW = "e w A p"
+  let ?set = "{e b A p | b. b \<in> A}" and
+      ?eMax = "Max {e b A p | b. b \<in> A}" and
+      ?eW = "e a A p"
   from f_prof
   have 0: "finite ?set"
     by simp
@@ -60,17 +65,18 @@ proof -
     by (metis (mono_tags, lifting))
   have 3: "\<forall> e \<in> ?set . e \<le> ?eW"
   proof (safe)
-    fix a :: "'a"
-    assume aInA: "a \<in> A"
-    have "\<forall>n na. (n::nat) \<noteq> na \<or> n \<le> na"
+    fix b :: "'a"
+    assume b_in_A: "b \<in> A"
+    have "\<forall> n na. (n::nat) \<noteq> na \<or> n \<le> na"
       by simp
-    with aInA show "e a A p \<le> e w A p"
+    with b_in_A
+    show "e b A p \<le> e a A p"
       using less_imp_le rating winner
       unfolding condorcet_rating_def
       by (metis (no_types))
   qed
-  from 2 3 have 4:
-    "?eW \<in> ?set \<and> (\<forall>a \<in> ?set. a \<le> ?eW)"
+  from 2 3
+  have 4: "?eW \<in> ?set \<and> (\<forall> a \<in> ?set. a \<le> ?eW)"
     by blast
   from 0 1 4 Max_eq_iff
   show ?thesis
@@ -85,19 +91,25 @@ text \<open>
 \<close>
 
 theorem non_cond_winner_not_max_eval:
+  fixes
+    e :: "'a Evaluation_Function" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a" and
+    b :: "'a"
   assumes
     rating: "condorcet_rating e" and
     f_prof: "finite_profile A p" and
-    winner: "condorcet_winner A p w" and
-    linA: "l \<in> A" and
-    loser: "w \<noteq> l"
-  shows "e l A p < Max {e a A p | a. a \<in> A}"
+    winner: "condorcet_winner A p a" and
+    lin_A: "b \<in> A" and
+    loser: "a \<noteq> b"
+  shows "e b A p < Max {e c A p | c. c \<in> A}"
 proof -
-  have "e l A p < e w A p"
-    using linA loser rating winner
+  have "e b A p < e a A p"
+    using lin_A loser rating winner
     unfolding condorcet_rating_def
     by metis
-  also have "e w A p = Max {e a A p |a. a \<in> A}"
+  also have "e a A p = Max {e c A p | c. c \<in> A}"
     using cond_winner_imp_max_eval_val f_prof rating winner
     by fastforce
   finally show ?thesis

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Maximum_Aggregator.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Maximum_Aggregator.thy
@@ -27,27 +27,32 @@ fun max_aggregator :: "'a Aggregator" where
 
 subsection \<open>Auxiliary Lemma\<close>
 
-lemma max_agg_rej_set: "(well_formed A (e1, r1, d1) \<and>
-                          well_formed A (e2, r2, d2)) \<longrightarrow>
-           reject_r (max_aggregator A (e1, r1, d1) (e2, r2, d2)) = r1 \<inter> r2"
-proof (clarify)
-  assume
-    wf1: "well_formed A (e1, r1, d1)" and
-    wf2: "well_formed A (e2, r2, d2)"
-  have "A - (e1 \<union> d1) = r1"
-    using wf1
+lemma max_agg_rej_set:
+  fixes
+    A :: "'a set" and
+    e :: "'a set" and
+    e' :: "'a set" and
+    d :: "'a set" and
+    d' :: "'a set" and
+    r :: "'a set" and
+    r' :: "'a set" and
+    a :: "'a"
+  assumes
+    wf_1: "well_formed A (e, r, d)" and
+    wf_2: "well_formed A (e', r', d')"
+  shows "reject_r (max_aggregator A (e, r, d) (e', r', d')) = r \<inter> r'"
+proof -
+  have "A - (e \<union> d) = r"
+    using wf_1
     by (simp add: result_imp_rej)
-  moreover have
-    "A - (e2 \<union> d2) = r2"
-    using wf2
+  moreover have "A - (e' \<union> d') = r'"
+    using wf_2
     by (simp add: result_imp_rej)
-  ultimately have
-    "A - (e1 \<union> e2 \<union> d1 \<union> d2) = r1 \<inter> r2"
+  ultimately have "A - (e \<union> e' \<union> d \<union> d') = r \<inter> r'"
     by blast
-  moreover have
-    "{l \<in> A. l \<notin> e1 \<union> e2 \<union> d1 \<union> d2} = A - (e1 \<union> e2 \<union> d1 \<union> d2)"
+  moreover have "{l \<in> A. l \<notin> e \<union> e' \<union> d \<union> d'} = A - (e \<union> e' \<union> d \<union> d')"
     by (simp add: set_diff_eq)
-  ultimately show "reject_r (max_aggregator A (e1, r1, d1) (e2, r2, d2)) = r1 \<inter> r2"
+  ultimately show "reject_r (max_aggregator A (e, r, d) (e', r', d')) = r \<inter> r'"
     by simp
 qed
 
@@ -57,36 +62,36 @@ theorem max_agg_sound[simp]: "aggregator max_aggregator"
 proof (unfold aggregator_def, simp, safe)
   fix
     A :: "'a set" and
-    e1 :: "'a set" and
-    e2 :: "'a set" and
-    d1 :: "'a set" and
-    d2 :: "'a set" and
-    r1 :: "'a set" and
-    r2 :: "'a set" and
-    x :: "'a"
+    e :: "'a set" and
+    e' :: "'a set" and
+    d :: "'a set" and
+    d' :: "'a set" and
+    r :: "'a set" and
+    r' :: "'a set" and
+    a :: "'a"
   assume
-    "e2 \<union> r2 \<union> d2 = e1 \<union> r1 \<union> d1" and
-    "x \<notin> d1" and
-    "x \<notin> r1" and
-    "x \<in> e2"
-  thus "x \<in> e1"
+    "e' \<union> r' \<union> d' = e \<union> r \<union> d" and
+    "a \<notin> d" and
+    "a \<notin> r" and
+    "a \<in> e'"
+  thus "a \<in> e"
     by auto
 next
   fix
     A :: "'a set" and
-    e1 :: "'a set" and
-    e2 :: "'a set" and
-    d1 :: "'a set" and
-    d2 :: "'a set" and
-    r1 :: "'a set" and
-    r2 :: "'a set" and
-    x :: "'a"
+    e :: "'a set" and
+    e' :: "'a set" and
+    d :: "'a set" and
+    d' :: "'a set" and
+    r :: "'a set" and
+    r' :: "'a set" and
+    a :: "'a"
   assume
-    "e2 \<union> r2 \<union> d2 = e1 \<union> r1 \<union> d1" and
-    "x \<notin> d1" and
-    "x \<notin> r1" and
-    "x \<in> d2"
-  thus "x \<in> e1"
+    "e' \<union> r' \<union> d' = e \<union> r \<union> d" and
+    "a \<notin> d" and
+    "a \<notin> r" and
+    "a \<in> d'"
+  thus "a \<in> e"
     by auto
 qed
 
@@ -104,67 +109,67 @@ proof (unfold agg_conservative_def, safe)
 next
   fix
     A :: "'a set" and
-    e1 :: "'a set" and
-    e2 :: "'a set" and
-    d1 :: "'a set" and
-    d2 :: "'a set" and
-    r1 :: "'a set" and
-    r2 :: "'a set" and
-    x :: "'a"
+    e :: "'a set" and
+    e' :: "'a set" and
+    d :: "'a set" and
+    d' :: "'a set" and
+    r :: "'a set" and
+    r' :: "'a set" and
+    a :: "'a"
   assume
-    elect_x: "x \<in> elect_r (max_aggregator A (e1, r1, d1) (e2, r2, d2))" and
-    x_not_in_e2: "x \<notin> e2"
-  have "x \<in> e1 \<union> e2"
-    using elect_x
+    elect_a: "a \<in> elect_r (max_aggregator A (e, r, d) (e', r', d'))" and
+    a_not_in_e': "a \<notin> e'"
+  have "a \<in> e \<union> e'"
+    using elect_a
     by simp
-  hence "x \<in> e1 \<union> e2"
+  hence "a \<in> e \<union> e'"
     by metis
-  thus "x \<in> e1"
-    using x_not_in_e2
-    by simp
-next
-  fix
-    A :: "'a set" and
-    e1 :: "'a set" and
-    e2 :: "'a set" and
-    d1 :: "'a set" and
-    d2 :: "'a set" and
-    r1 :: "'a set" and
-    r2 :: "'a set" and
-    x :: "'a"
-  assume
-    wf2: "well_formed A (e2, r2, d2)" and
-    reject_x: "x \<in> reject_r (max_aggregator A (e1, r1, d1) (e2, r2, d2))" and
-    x_not_in_r2: "x \<notin> r2"
-  have "x \<in> r1 \<union> r2"
-    using wf2 reject_x
-    by force
-  hence "x \<in> r1 \<union> r2"
-    by metis
-  thus "x \<in> r1"
-    using x_not_in_r2
+  thus "a \<in> e"
+    using a_not_in_e'
     by simp
 next
   fix
     A :: "'a set" and
-    e1 :: "'a set" and
-    e2 :: "'a set" and
-    d1 :: "'a set" and
-    d2 :: "'a set" and
-    r1 :: "'a set" and
-    r2 :: "'a set" and
-    x :: "'a"
+    e :: "'a set" and
+    e' :: "'a set" and
+    d :: "'a set" and
+    d' :: "'a set" and
+    r :: "'a set" and
+    r' :: "'a set" and
+    a :: "'a"
   assume
-    wf2: "well_formed A (e2, r2, d2)" and
-    defer_x: "x \<in> defer_r (max_aggregator A (e1, r1, d1) (e2, r2, d2))" and
-    x_not_in_d2: "x \<notin> d2"
-  have "x \<in> d1 \<union> d2"
-    using wf2 defer_x
+    wf_2: "well_formed A (e', r', d')" and
+    reject_a: "a \<in> reject_r (max_aggregator A (e, r, d) (e', r', d'))" and
+    a_not_in_r': "a \<notin> r'"
+  have "a \<in> r \<union> r'"
+    using wf_2 reject_a
     by force
-  hence "x \<in> d1 \<union> d2"
+  hence "a \<in> r \<union> r'"
     by metis
-  thus "x \<in> d1"
-    using x_not_in_d2
+  thus "a \<in> r"
+    using a_not_in_r'
+    by simp
+next
+  fix
+    A :: "'a set" and
+    e :: "'a set" and
+    e' :: "'a set" and
+    d :: "'a set" and
+    d' :: "'a set" and
+    r :: "'a set" and
+    r' :: "'a set" and
+    a :: "'a"
+  assume
+    wf_2: "well_formed A (e', r', d')" and
+    defer_a: "a \<in> defer_r (max_aggregator A (e, r, d) (e', r', d'))" and
+    a_not_in_d': "a \<notin> d'"
+  have "a \<in> d \<union> d'"
+    using wf_2 defer_a
+    by force
+  hence "a \<in> d \<union> d'"
+    by metis
+  thus "a \<in> d"
+    using a_not_in_d'
     by simp
 qed
 
@@ -173,19 +178,7 @@ text \<open>
 \<close>
 
 theorem max_agg_comm[simp]: "agg_commutative max_aggregator"
-proof (unfold agg_commutative_def, safe, simp)
-  fix
-    A :: "'a set" and
-    e1 :: "'a set" and
-    e2 :: "'a set" and
-    d1 :: "'a set" and
-    d2 :: "'a set" and
-    r1 :: "'a set" and
-    r2 :: "'a set"
-  show
-    "max_aggregator A (e1, r1, d1) (e2, r2, d2) =
-      max_aggregator A (e2, r2, d2) (e1, r1, d1)"
+  unfolding agg_commutative_def
   by auto
-qed
 
 end

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Preference_Relation.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Preference_Relation.thy
@@ -626,6 +626,33 @@ proof -
     by metis
 qed
 
+
+lemma rankone1: assumes "above r a = {a}"
+  shows "rank r a = 1"
+  unfolding rank.simps using assms by auto
+
+lemma rankone2: assumes
+ lo: "linear_order_on A r" and 
+ ro: "rank r a = 1"
+shows "above r a = {a}"
+proof -
+  from lo have refl: "refl_on A r"
+    using linear_order_on_def partial_order_onD(1) by blast 
+  from lo ro have "a \<in> A" unfolding rank.simps above_def linear_order_on_def 
+    partial_order_on_def preorder_on_def total_on_def
+    by (metis card_1_singletonE insertI1 mem_Collect_eq refl_onD1) 
+  from this refl have "a \<in> above r a"
+    using above_refl by fastforce
+  from this ro show "above r a = {a}"
+    by (metis card_1_singletonE rank.simps singletonD)
+qed
+
+theorem above_rank: assumes
+ lo: "linear_order_on A r"
+  shows "above r a = {a} \<longleftrightarrow> rank r a = 1"
+  by (metis lo rankone1 rankone2)
+  
+
 lemma above_presv_limit:
   shows "above (limit A r) x \<subseteq> A"
   unfolding above_def

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Profile.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Profile.thy
@@ -38,7 +38,11 @@ text \<open>
 definition profile :: "'a set \<Rightarrow> 'a Profile \<Rightarrow> bool" where
   "profile A p \<equiv> \<forall> i::nat. i < length p \<longrightarrow> linear_order_on A (p!i)"
 
-lemma profile_set : "profile A p \<equiv> (\<forall> b \<in> (set p). linear_order_on A b)"
+lemma profile_set :
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile"
+  shows "profile A p \<equiv> (\<forall> b \<in> (set p). linear_order_on A b)"
   unfolding profile_def all_set_conv_all_nth
   by simp
 
@@ -61,7 +65,11 @@ fun win_count_code :: "'a Profile \<Rightarrow> 'a \<Rightarrow> nat" where
   "win_count_code (p#ps) a =
       (if (above p a = {a}) then 1 else 0) + win_count_code ps a"
 
-lemma win_count_equiv[code]: "win_count p x = win_count_code p x"
+lemma win_count_equiv[code]:
+  fixes
+    p :: "'a Profile" and
+    x :: "'a"
+  shows "win_count p x = win_count_code p x"
 proof (induction p rule: rev_induct, simp)
   case (snoc a p)
   fix
@@ -70,8 +78,7 @@ proof (induction p rule: rev_induct, simp)
   assume base_case: "win_count p x = win_count_code p x"
   have size_one: "length [a] = 1"
     by simp
-  have p_pos_in_ps:
-    "\<forall> i < length p. p!i = (p@[a])!i"
+  have p_pos_in_ps: "\<forall> i < length p. p!i = (p@[a])!i"
     by (simp add: nth_append)
   have
     "win_count [a] x =
@@ -79,8 +86,7 @@ proof (induction p rule: rev_induct, simp)
         card {i::nat. i < length q \<and>
               (let r = (q!i) in (above r x = {x}))})"
     by simp
-  hence one_ballot_equiv:
-    "win_count [a] x = win_count_code [a] x"
+  hence one_ballot_equiv: "win_count [a] x = win_count_code [a] x"
     using size_one
     by (simp add: nth_Cons')
   have pref_count_induct:
@@ -101,113 +107,113 @@ proof (induction p rule: rev_induct, simp)
           {i. i = length p \<and> (above ([a]!0) x = {x})}"
     proof (safe, simp_all)
       fix
-        xa :: nat and
-        xaa :: "'a"
+        n :: nat and
+        n' :: "'a"
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
-        "xa \<noteq> length p" and
-        "xaa \<in> above (p!xa) x"
-      thus "xaa = x"
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
+        "n \<noteq> length p" and
+        "n' \<in> above (p!n) x"
+      thus "n' = x"
         using less_antisym p_pos_in_ps singletonD
         by metis
     next
-      fix xa :: nat
+      fix n :: nat
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
-        "xa \<noteq> length p"
-      thus "x \<in> above (p!xa) x"
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
+        "n \<noteq> length p"
+      thus "x \<in> above (p!n) x"
         using less_antisym insertI1 p_pos_in_ps
         by metis
     next
       fix
-        xa :: nat and
-        xaa :: "'a"
+        n :: nat and
+        b :: "'a"
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
-        "xaa \<in> above a x" and
-        "xaa \<noteq> x"
-      thus "xa < length p"
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
+        "b \<in> above a x" and
+        "b \<noteq> x"
+      thus "n < length p"
         using less_antisym nth_append_length
               p_pos_in_ps singletonD
         by metis
     next
       fix
-        xa :: nat and
-        xaa :: "'a" and
-        xb :: "'a"
+        n :: nat and
+        b :: "'a" and
+        b' :: "'a"
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
-        "xaa \<in> above a x" and
-        "xaa \<noteq> x" and
-        "xb \<in> above (p!xa) x"
-      thus "xb = x"
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
+        "b \<in> above a x" and
+        "b \<noteq> x" and
+        "b' \<in> above (p!n) x"
+      thus "b' = x"
         using less_antisym p_pos_in_ps
               nth_append_length singletonD
         by metis
     next
       fix
-        xa :: nat and
-        xaa :: "'a"
+        n :: nat and
+        b :: "'a"
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
-        "xaa \<in> above a x" and
-        "xaa \<noteq> x"
-      thus "x \<in> above (p!xa) x"
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
+        "b \<in> above a x" and
+        "b \<noteq> x"
+      thus "x \<in> above (p!n) x"
         using insertI1 less_antisym nth_append
               nth_append_length singletonD
         by metis
     next
-      fix xa :: nat
+      fix n :: nat
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
         "x \<notin> above a x"
-      thus "xa < length p"
+      thus "n < length p"
         using insertI1 less_antisym nth_append_length
         by metis
     next
       fix
-        xa :: nat and
-        xb :: "'a"
+        n :: nat and
+        b :: "'a"
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
         "x \<notin> above a x" and
-        "xb \<in> above (p!xa) x"
-      thus "xb = x"
+        "b \<in> above (p!n) x"
+      thus "b = x"
         using insertI1 less_antisym nth_append_length
               p_pos_in_ps singletonD
         by metis
     next
-      fix xa :: nat
+      fix n :: nat
       assume
-        "xa < Suc (length p)" and
-        "above ((p@[a])!xa) x = {x}" and
+        "n < Suc (length p)" and
+        "above ((p@[a])!n) x = {x}" and
         "x \<notin> above a x"
-      thus "x \<in> above (p!xa) x"
+      thus "x \<in> above (p!n) x"
         using insertI1 less_antisym nth_append_length p_pos_in_ps
         by metis
     next
       fix
-        xa :: nat and
-        xaa :: "'a"
+        n :: nat and
+        b :: "'a"
       assume
-        "xa < length p" and
-        "above (p!xa) x = {x}" and
-        "xaa \<in> above ((p@[a])!xa) x"
-      thus "xaa = x"
+        "n < length p" and
+        "above (p!n) x = {x}" and
+        "b \<in> above ((p@[a])!n) x"
+      thus "b = x"
         by (simp add: nth_append)
     next
-      fix xa :: nat
+      fix n :: nat
       assume
-        "xa < length p" and
-        "above (p!xa) x = {x}"
-      thus "x \<in> above ((p@[a])!xa) x"
+        "n < length p" and
+        "above (p!n) x = {x}"
+      thus "x \<in> above ((p@[a])!n) x"
         by (simp add: nth_append)
     qed
     have fin_len_p:
@@ -233,14 +239,14 @@ proof (induction p rule: rev_induct, simp)
   have "win_count_code (p@[a]) x = win_count_code p x + win_count_code [a] x"
   proof (induction p, simp)
     fix
-      aa :: "'a Preference_Relation" and
-      p :: "'a Profile"
+      r :: "'a Preference_Relation" and
+      q :: "'a Profile"
     assume
-      "win_count_code (p@[a]) x =
-        win_count_code p x + win_count_code [a] x"
+      "win_count_code (q@[a]) x =
+        win_count_code q x + win_count_code [a] x"
     thus
-      "win_count_code ((aa#p)@[a]) x =
-        win_count_code (aa#p) x + win_count_code [a] x"
+      "win_count_code ((r#q)@[a]) x =
+        win_count_code (r#q) x + win_count_code [a] x"
       by simp
   qed
   thus "win_count (p@[a]) x = win_count_code (p@[a]) x"
@@ -257,7 +263,12 @@ fun prefer_count_code :: "'a Profile \<Rightarrow> 'a \<Rightarrow> 'a \<Rightar
   "prefer_count_code (p#ps) x y =
       (if y \<preceq>\<^sub>p x then 1 else 0) + prefer_count_code ps x y"
 
-lemma pref_count_equiv[code]: "prefer_count p x y = prefer_count_code p x y"
+lemma pref_count_equiv[code]:
+  fixes
+    p :: "'a Profile" and
+    x :: "'a" and
+    y :: "'a"
+  shows "prefer_count p x y = prefer_count_code p x y"
 proof (induction p rule: rev_induct, simp)
   case (snoc a p)
   fix
@@ -376,14 +387,27 @@ proof (induction p rule: rev_induct, simp)
     by presburger
 qed
 
-lemma set_compr: "{ f x | x . x \<in> S } = f ` S"
+lemma set_compr:
+  fixes
+    S :: "'a set" and
+    f :: "'a \<Rightarrow> 'a set"
+  shows "{ f x | x. x \<in> S } = f ` S"
   by auto
 
-lemma pref_count_set_compr: "{prefer_count p x y | y . y \<in> A - {x}} =
-          (prefer_count p x) ` (A - {x})"
+lemma pref_count_set_compr:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    x :: "'a"
+  shows "{prefer_count p x y | y. y \<in> A - {x}} = (prefer_count p x) ` (A - {x})"
   by auto
 
 lemma pref_count:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    x :: "'a" and
+    y :: "'a"
   assumes
     prof: "profile A p" and
     x_in_A: "x \<in> A" and
@@ -398,29 +422,30 @@ proof -
         {i::nat. i < length p} -
           {i::nat. i < length p \<and> \<not> (let r = (p!i) in (y \<preceq>\<^sub>r x))}"
     by auto
-  have 0: "\<forall> i::nat . i < length p \<longrightarrow> linear_order_on A (p!i)"
+  have 0: "\<forall> i::nat. i < length p \<longrightarrow> linear_order_on A (p!i)"
     using prof
     unfolding profile_def
     by simp
-  hence "\<forall> i::nat . i < length p \<longrightarrow> connex A (p!i)"
+  hence "\<forall> i::nat. i < length p \<longrightarrow> connex A (p!i)"
     by (simp add: lin_ord_imp_connex)
-  hence 1: "\<forall> i::nat . i < length p \<longrightarrow>
+  hence 1: "\<forall> i::nat. i < length p \<longrightarrow>
               \<not> (let r = (p!i) in (y \<preceq>\<^sub>r x)) \<longrightarrow> (let r = (p!i) in (x \<preceq>\<^sub>r y))"
     using x_in_A y_in_A
     unfolding connex_def
     by metis
-  from 0 have
-    "\<forall> i::nat . i < length p \<longrightarrow> antisym  (p!i)"
+  from 0
+  have "\<forall> i::nat. i < length p \<longrightarrow> antisym  (p!i)"
     using lin_imp_antisym
     by metis
-  hence "\<forall> i::nat . i < length p \<longrightarrow> ((y, x) \<in> (p!i) \<longrightarrow> (x, y) \<notin> (p!i))"
+  hence "\<forall> i::nat. i < length p \<longrightarrow> ((y, x) \<in> (p!i) \<longrightarrow> (x, y) \<notin> (p!i))"
     using antisymD neq
     by metis
-  hence "\<forall> i::nat . i < length p \<longrightarrow>
+  hence "\<forall> i::nat. i < length p \<longrightarrow>
           ((let r = (p!i) in (y \<preceq>\<^sub>r x)) \<longrightarrow> \<not> (let r = (p!i) in (x \<preceq>\<^sub>r y)))"
     by simp
-  with 1 have
-    "\<forall> i::nat . i < length p \<longrightarrow>
+  with 1
+  have
+    "\<forall> i::nat. i < length p \<longrightarrow>
       \<not> (let r = (p!i) in (y \<preceq>\<^sub>r x)) = (let r = (p!i) in (x \<preceq>\<^sub>r y))"
     by metis
   hence 2:
@@ -441,19 +466,19 @@ proof -
     "card ({i::nat. i < length p} -
         {i::nat. i < length p \<and> (let r = (p!i) in (x \<preceq>\<^sub>r y))}) =
       (card {i::nat. i < length p}) -
-        card({i::nat. i < length p \<and> (let r = (p!i) in (x \<preceq>\<^sub>r y))})"
+        card ({i::nat. i < length p \<and> (let r = (p!i) in (x \<preceq>\<^sub>r y))})"
     by (simp add: card_Diff_subset)
   have "prefer_count p x y =
           card {i::nat. i < length p \<and> (let r = (p!i) in (y \<preceq>\<^sub>r x))}"
     by simp
   also have
-    "... = card({i::nat. i < length p} -
+    "... = card ({i::nat. i < length p} -
             {i::nat. i < length p \<and> (let r = (p!i) in (x \<preceq>\<^sub>r y))})"
     using 20
     by simp
   also have
     "... = (card {i::nat. i < length p}) -
-              card({i::nat. i < length p \<and> (let r = (p!i) in (x \<preceq>\<^sub>r y))})"
+              card ({i::nat. i < length p \<and> (let r = (p!i) in (x \<preceq>\<^sub>r y))})"
     using 30
     by metis
   also have
@@ -464,53 +489,66 @@ proof -
 qed
 
 lemma pref_count_sym:
+  fixes
+    p :: "'a Profile" and
+    x :: "'a" and
+    a :: "'a" and
+    b :: "'a"
   assumes
-    p1: "prefer_count p a x \<ge> prefer_count p x b" and
+    pref_count_ineq: "prefer_count p a x \<ge> prefer_count p x b" and
     prof: "profile A p" and
     a_in_A: "a \<in> A" and
     b_in_A: "b \<in> A" and
     x_in_A: "x \<in> A" and
-    neq1: "a \<noteq> x" and
-    neq2: "x \<noteq> b"
+    neq_1: "a \<noteq> x" and
+    neq_2: "x \<noteq> b"
   shows "prefer_count p b x \<ge> prefer_count p x a"
 proof -
-  from prof a_in_A x_in_A neq1 have 0:
-    "prefer_count p a x = (length p) - (prefer_count p x a)"
+  from prof a_in_A x_in_A neq_1
+  have 0: "prefer_count p a x = (length p) - (prefer_count p x a)"
     using pref_count
     by metis
-  moreover from prof x_in_A b_in_A neq2 have 1:
-    "prefer_count p x b = (length p) - (prefer_count p b x)"
+  moreover from prof x_in_A b_in_A neq_2
+  have 1: "prefer_count p x b = (length p) - (prefer_count p b x)"
     using pref_count
     by (metis (mono_tags, lifting))
   hence 2: "(length p) - (prefer_count p x a) \<ge>
               (length p) - (prefer_count p b x)"
-    using calculation p1
+    using calculation pref_count_ineq
     by auto
   hence 3: "(prefer_count p x a) - (length p) \<le>
               (prefer_count p b x) - (length p)"
-    using a_in_A diff_is_0_eq diff_le_self neq1
+    using a_in_A diff_is_0_eq diff_le_self neq_1
           pref_count prof x_in_A
     by (metis (no_types))
   hence "(prefer_count p x a) \<le> (prefer_count p b x)"
-    using 1 3 calculation p1
+    using 1 3 calculation pref_count_ineq
     by linarith
   thus ?thesis
     by linarith
 qed
 
 lemma empty_prof_imp_zero_pref_count:
+  fixes p :: "'a Profile"
   assumes "p = []"
   shows "\<forall> x y. prefer_count p x y = 0"
   using assms
   by simp
 
 lemma empty_prof_imp_zero_pref_count_code:
+  fixes p :: "'a Profile"
   assumes "p = []"
   shows "\<forall> x y. prefer_count_code p x y = 0"
   using assms
   by simp
 
 lemma pref_count_code_incr:
+  fixes
+    ps :: "'a Profile" and
+    p :: "'a Preference_Relation" and
+    x :: "'a" and
+    y :: "'a" and
+    n :: nat
   assumes
     "prefer_count_code ps x y = n" and
     "y \<preceq>\<^sub>p x"
@@ -519,6 +557,12 @@ lemma pref_count_code_incr:
   by simp
 
 lemma pref_count_code_not_smaller_imp_constant:
+  fixes
+    ps :: "'a Profile" and
+    p :: "'a Preference_Relation" and
+    x :: "'a" and
+    y :: "'a" and
+    n :: nat
   assumes
     "prefer_count_code ps x y = n" and
     "\<not>(y \<preceq>\<^sub>p x)"
@@ -535,12 +579,20 @@ text \<open>
 \<close>
 
 lemma wins_antisym:
+  fixes
+    p :: "'a Profile" and
+    a :: "'a" and
+    b :: "'a"
   assumes "wins a p b"
   shows "\<not> wins b p a"
   using assms
   by simp
 
-lemma wins_irreflex: "\<not> wins w p w"
+lemma wins_irreflex:
+  fixes
+    p :: "'a Profile" and
+    a :: "'a"
+  shows "\<not> wins a p a"
   using wins_antisym
   by metis
 
@@ -548,112 +600,131 @@ subsection \<open>Condorcet Winner\<close>
 
 fun condorcet_winner :: "'a set \<Rightarrow> 'a Profile \<Rightarrow> 'a \<Rightarrow> bool" where
   "condorcet_winner A p w =
-      (finite_profile A p \<and>  w \<in> A \<and> (\<forall> x \<in> A - {w} . wins w p x))"
+      (finite_profile A p \<and>  w \<in> A \<and> (\<forall> x \<in> A - {w}. wins w p x))"
 
 lemma cond_winner_unique:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a" and
+    b :: "'a"
   assumes
-    winner_c: "condorcet_winner A p c" and
-    winner_w: "condorcet_winner A p w"
-  shows "w = c"
+    winner_a: "condorcet_winner A p a" and
+    winner_b: "condorcet_winner A p b"
+  shows "b = a"
 proof (rule ccontr)
-  assume w_neq_c: "w \<noteq> c"
-  from winner_w
-  have "wins w p c"
-    using w_neq_c insert_Diff insert_iff winner_c
+  assume b_neq_a: "b \<noteq> a"
+  from winner_b
+  have "wins b p a"
+    using b_neq_a insert_Diff insert_iff winner_a
     by simp
-  hence "\<not> wins c p w"
+  hence "\<not> wins a p b"
     by (simp add: wins_antisym)
-  moreover from winner_c
+  moreover from winner_a
   have
-    c_wins_against_w: "wins c p w"
-    using Diff_iff w_neq_c
-          singletonD winner_w
+    a_wins_against_b: "wins a p b"
+    using Diff_iff b_neq_a
+          singletonD winner_b
     by simp
   ultimately show False
     by simp
 qed
 
-lemma cond_winner_unique2:
+lemma cond_winner_unique_2:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a" and
+    b :: "'a"
   assumes
-    winner: "condorcet_winner A p w" and
-    not_w:  "x \<noteq> w"
-  shows "\<not> condorcet_winner A p x"
-  using not_w cond_winner_unique winner
+    winner: "condorcet_winner A p a" and
+    not_a:  "b \<noteq> a"
+  shows "\<not> condorcet_winner A p b"
+  using not_a cond_winner_unique winner
   by metis
 
-lemma cond_winner_unique3:
-  assumes "condorcet_winner A p w"
-  shows "{a \<in> A. condorcet_winner A p a} = {w}"
+lemma cond_winner_unique_3:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
+  assumes "condorcet_winner A p a"
+  shows "{b \<in> A. condorcet_winner A p b} = {a}"
 proof (safe, simp_all, safe)
-  fix x :: "'a"
+  fix b :: "'a"
   assume
     fin_A: "finite A" and
     prof_A: "profile A p" and
-    x_in_A: "x \<in> A" and
-    x_wins:
-      "\<forall> xa \<in> A - {x}.
-        card {i. i < length p \<and> (x, xa) \<in> p!i} <
-          card {i. i < length p \<and> (xa, x) \<in> p!i}"
-  from assms have assm:
-    "finite_profile A p \<and>  w \<in> A \<and>
-      (\<forall> x \<in> A - {w}.
-        card {i::nat. i < length p \<and> (w, x) \<in> p!i} <
-          card {i::nat. i < length p \<and> (x, w) \<in> p!i})"
+    b_in_A: "b \<in> A" and
+    b_wins:
+      "\<forall> x \<in> A - {b}.
+        card {i. i < length p \<and> (b, x) \<in> p!i} <
+          card {i. i < length p \<and> (x, b) \<in> p!i}"
+  from assms
+  have assm:
+    "finite_profile A p \<and>  a \<in> A \<and>
+      (\<forall> x \<in> A - {a}.
+        card {i::nat. i < length p \<and> (a, x) \<in> p!i} <
+          card {i::nat. i < length p \<and> (x, a) \<in> p!i})"
     by simp
   hence
-    "(\<forall> x \<in> A - {w}.
-      card {i::nat. i < length p \<and> (w, x) \<in> p!i} <
-        card {i::nat. i < length p \<and> (x, w) \<in> p!i})"
+    "(\<forall> x \<in> A - {a}.
+      card {i::nat. i < length p \<and> (a, x) \<in> p!i} <
+        card {i::nat. i < length p \<and> (x, a) \<in> p!i})"
     by simp
-  hence w_beats_x:
-    "x \<noteq> w \<Longrightarrow>
-      card {i::nat. i < length p \<and> (w, x) \<in> p!i} <
-        card {i::nat. i < length p \<and> (x, w) \<in> p!i}"
-    using x_in_A
+  hence a_beats_b:
+    "b \<noteq> a \<Longrightarrow>
+      card {i::nat. i < length p \<and> (a, b) \<in> p!i} <
+        card {i::nat. i < length p \<and> (b, a) \<in> p!i}"
+    using b_in_A
     by simp
-  also from assm have
-    "finite_profile A p"
+  also from assm
+  have "finite_profile A p"
     by simp
-  moreover from assm have
-    "w \<in> A"
+  moreover from assm
+  have "a \<in> A"
     by simp
-  hence x_beats_w:
-    "x \<noteq> w \<Longrightarrow>
-      card {i. i < length p \<and> (x, w) \<in> p!i} <
-        card {i. i < length p \<and> (w, x) \<in> p!i}"
-    using x_wins
+  hence b_beats_a:
+    "b \<noteq> a \<Longrightarrow>
+      card {i. i < length p \<and> (b, a) \<in> p!i} <
+        card {i. i < length p \<and> (a, b) \<in> p!i}"
+    using b_wins
     by simp
-  from w_beats_x x_beats_w show "x = w"
+  from a_beats_b b_beats_a
+  show "b = a"
     by linarith
 next
-  from assms show "w \<in> A"
+  from assms
+  show "a \<in> A"
     by simp
 next
-  from assms show "finite A"
+  from assms
+  show "finite A"
     by simp
 next
-  from assms show "profile A p"
+  from assms
+  show "profile A p"
     by simp
 next
-  from assms show "w \<in> A"
+  from assms
+  show "a \<in> A"
     by simp
 next
-  fix
-    x :: "'a" and
-    x' :: "'a"
+  fix b :: "'a"
   assume
-    x_prime_in_A: "x' \<in> A" and
-    w_wins:
-      "\<not> card {i. i < length p \<and> (w, x') \<in> p!i} <
-        card {i. i < length p \<and> (x', w) \<in> p!i}"
-  from assms have
-    "finite_profile A p \<and>  w \<in> A \<and>
-      (\<forall> x \<in> A - {w} .
-        card {i::nat. i < length p \<and> (w, x) \<in> p!i} <
-          card {i::nat. i < length p \<and> (x, w) \<in> p!i})"
+    b_in_A: "b \<in> A" and
+    a_wins:
+      "\<not> card {i. i < length p \<and> (a, b) \<in> p!i} <
+        card {i. i < length p \<and> (b, a) \<in> p!i}"
+  from assms
+  have
+    "finite_profile A p \<and> a \<in> A \<and>
+      (\<forall> x \<in> A - {a}.
+        card {i::nat. i < length p \<and> (a, x) \<in> p!i} <
+          card {i::nat. i < length p \<and> (x, a) \<in> p!i})"
     by simp
-  thus "x' = w"
-    using x_prime_in_A w_wins insert_Diff insert_iff
+  thus "b = a"
+    using b_in_A a_wins insert_Diff insert_iff
     by (metis (no_types, lifting))
 qed
 
@@ -668,21 +739,30 @@ fun limit_profile :: "'a set \<Rightarrow> 'a Profile \<Rightarrow> 'a Profile" 
   "limit_profile A p = map (limit A) p"
 
 lemma limit_prof_trans:
+  fixes
+    A :: "'a set" and
+    B :: "'a set" and
+    C :: "'a set" and
+    p :: "'a Profile"
   assumes
     "B \<subseteq> A" and
-    "B' \<subseteq> B" and
+    "C \<subseteq> B" and
     "finite_profile A p"
-  shows "limit_profile B' p = limit_profile B' (limit_profile B p)"
+  shows "limit_profile C p = limit_profile C (limit_profile B p)"
   using assms
   by auto
 
 lemma limit_profile_sound:
+  fixes
+    A :: "'a set" and
+    B :: "'a set" and
+    p :: "'a Profile"
   assumes
-    profile: "finite_profile S p" and
-    subset: "A \<subseteq> S"
+    profile: "finite_profile B p" and
+    subset: "A \<subseteq> B"
   shows "finite_profile A (limit_profile A p)"
 proof (safe)
-  have "\<forall> A A'. finite (A::'a set) \<longrightarrow> A' \<subseteq> A \<longrightarrow> finite A'"
+  have "finite B \<longrightarrow> A \<subseteq> B \<longrightarrow> finite A"
     using rev_finite_subset
     by metis
   with profile
@@ -691,25 +771,25 @@ proof (safe)
     by metis
 next
   have prof_is_lin_ord:
-    "\<forall> A r.
-      (profile (A::'a set) r \<longrightarrow> (\<forall> n < length r. linear_order_on A (r!n))) \<and>
-      ((\<forall> n < length r. linear_order_on A (r!n)) \<longrightarrow> profile A r)"
+    "\<forall> C q.
+      (profile (C::'a set) q \<longrightarrow> (\<forall> n < length q. linear_order_on C (q!n))) \<and>
+      ((\<forall> n < length q. linear_order_on C (q!n)) \<longrightarrow> profile C q)"
     unfolding profile_def
     by simp
   have limit_prof_simp: "limit_profile A p = map (limit A) p"
     by simp
-  obtain n' :: nat where
-    prof_limit_n: "(n' < length (limit_profile A p) \<longrightarrow>
-            linear_order_on A (limit_profile A p!n')) \<longrightarrow>
+  obtain n :: nat where
+    prof_limit_n: "(n < length (limit_profile A p) \<longrightarrow>
+            linear_order_on A (limit_profile A p!n)) \<longrightarrow>
           profile A (limit_profile A p)"
     using prof_is_lin_ord
     by metis
-  have prof_n_lin_ord: "\<forall> n < length p. linear_order_on S (p!n)"
+  have prof_n_lin_ord: "\<forall> n < length p. linear_order_on B (p!n)"
     using prof_is_lin_ord profile
     by simp
   have prof_length: "length p = length (map (limit A) p)"
     by simp
-  have "n' < length p \<longrightarrow> linear_order_on S (p!n')"
+  have "n < length p \<longrightarrow> linear_order_on B (p!n)"
     using prof_n_lin_ord
     by simp
   thus "profile A (limit_profile A p)"
@@ -717,13 +797,16 @@ next
     by (metis (no_types))
 qed
 
-lemma limit_prof_presv_size: "length p = length (limit_profile A p)"
+lemma limit_prof_presv_size:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile"
+  shows "length p = length (limit_profile A p)"
   by simp
 
 subsection \<open>Lifting Property\<close>
 
-definition equiv_prof_except_a :: "'a set \<Rightarrow> 'a Profile \<Rightarrow> 'a Profile \<Rightarrow>
-                                        'a \<Rightarrow> bool" where
+definition equiv_prof_except_a :: "'a set \<Rightarrow> 'a Profile \<Rightarrow> 'a Profile \<Rightarrow> 'a \<Rightarrow> bool" where
   "equiv_prof_except_a A p q a \<equiv>
     finite_profile A p \<and> finite_profile A q \<and>
       a \<in> A \<and> length p = length q \<and>
@@ -746,6 +829,11 @@ definition lifted :: "'a set \<Rightarrow> 'a Profile \<Rightarrow> 'a Profile \
       (\<exists> i::nat. i < length p \<and> Preference_Relation.lifted A (p!i) (q!i) a)"
 
 lemma lifted_imp_equiv_prof_except_a:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile" and
+    a :: "'a"
   assumes "lifted A p q a"
   shows "equiv_prof_except_a A p q a"
 proof (unfold equiv_prof_except_a_def, safe)
@@ -789,19 +877,25 @@ next
 qed
 
 lemma negl_diff_imp_eq_limit_prof:
+  fixes
+    A :: "'a set" and
+    B :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile" and
+    a :: "'a"
   assumes
-    change: "equiv_prof_except_a S p q a" and
-    subset: "A \<subseteq> S" and
-    notInA: "a \<notin> A"
+    change: "equiv_prof_except_a B p q a" and
+    subset: "A \<subseteq> B" and
+    not_in_A: "a \<notin> A"
   shows "limit_profile A p = limit_profile A q"
 proof (simp)
   have
     "\<forall> i::nat. i < length p \<longrightarrow>
-      equiv_rel_except_a S (p!i) (q!i) a"
+      equiv_rel_except_a B (p!i) (q!i) a"
     using change equiv_prof_except_a_def
     by metis
   hence "\<forall> i::nat. i < length p \<longrightarrow> limit A (p!i) = limit A (q!i)"
-    using notInA negl_diff_imp_eq_limit subset
+    using not_in_A negl_diff_imp_eq_limit subset
     by metis
   thus "map (limit A) p = map (limit A) q"
     using change equiv_prof_except_a_def
@@ -810,17 +904,23 @@ proof (simp)
 qed
 
 lemma limit_prof_eq_or_lifted:
+  fixes
+    A :: "'a set" and
+    B :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile" and
+    a :: "'a"
   assumes
-    lifted_a: "lifted S p q a" and
-    subset: "A \<subseteq> S"
+    lifted_a: "lifted B p q a" and
+    subset: "A \<subseteq> B"
   shows
     "limit_profile A p = limit_profile A q \<or>
         lifted A (limit_profile A p) (limit_profile A q) a"
 proof (cases)
-  assume inA: "a \<in> A"
+  assume a_in_A: "a \<in> A"
   have
     "\<forall> i::nat. i < length p \<longrightarrow>
-        (Preference_Relation.lifted S (p!i) (q!i) a \<or> (p!i) = (q!i))"
+        (Preference_Relation.lifted B (p!i) (q!i) a \<or> (p!i) = (q!i))"
     using lifted_a
     unfolding lifted_def
     by metis
@@ -850,8 +950,7 @@ proof (cases)
       using lifted_a
       unfolding lifted_def
       by fastforce
-    moreover have
-      "\<exists> i::nat. i < length ?p \<and> Preference_Relation.lifted A (?p!i) (?q!i) a"
+    moreover have "\<exists> i::nat. i < length ?p \<and> Preference_Relation.lifted A (?p!i) (?q!i) a"
       using forall_limit_p_q length_map lifted_a limit_profile.simps nth_map one
       unfolding lifted_def
       by (metis (no_types, lifting))
@@ -863,7 +962,7 @@ proof (cases)
       unfolding lifted_def
       by metis
     ultimately have "lifted A ?p ?q a"
-      using inA lifted_a rev_finite_subset subset
+      using a_in_A lifted_a rev_finite_subset subset
       unfolding lifted_def
       by (metis (no_types, lifting))
     thus ?thesis

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Preference_List.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Preference_List.thy
@@ -108,38 +108,35 @@ theorem aboveeq:
   fixes A :: "'a set" and l :: "'a Preference_List" and a :: 'a
   assumes wf: "well_formed_pl l" and lo: "linear_order_on_l A l"
   shows "set (above_l l a) = Order_Relation.above (pl_\<alpha> l) a"
-proof
-  show "set (above_l l a) \<subseteq> above (pl_\<alpha> l) a"
-  proof clarify
-    fix x :: 'a
-    assume "x \<in> set (Preference_List.above_l l a)"
-    have "length (above_l l a) = rank_l l a" unfolding above_l_def
-      by (simp add: Suc_le_eq in_set_member)
-    from wf lo this have "index l x \<le> index l a" unfolding rank_l.simps
-      by (metis Preference_List.above_l_def Preference_List.rank_l.simps Suc_eq_plus1 Suc_le_eq \<open>x \<in> set (Preference_List.above_l l a)\<close> bot_nat_0.extremum_strict index_take linorder_not_less)
-    from this have "a \<lesssim>\<^sub>l x"
-      by (metis One_nat_def Preference_List.above_l_def Preference_List.is_less_preferred_than.elims(3) Preference_List.rank_l.simps Suc_le_mono \<open>x \<in> set (Preference_List.above_l l a)\<close> add.commute add_0 add_Suc empty_iff find_index_le_size in_set_member index_def le_antisym list.set(1) size_index_conv take_0)
-    from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
-      using less_preffered_l_rel_eq by (metis)
-    from this show "x \<in> Order_Relation.above (pl_\<alpha> l) a"
-      using pref_imp_in_above by (metis)
-  qed
+proof safe
+  fix x :: 'a
+  assume xmem: "x \<in> set (Preference_List.above_l l a)"
+  have "length (above_l l a) = rank_l l a" unfolding above_l_def
+    by (simp add: Suc_le_eq in_set_member)
+  from xmem wf lo this have "index l x \<le> index l a" unfolding rank_l.simps using above_l_def
+    by (metis  Preference_List.rank_l.simps Suc_eq_plus1 
+        Suc_le_eq bot_nat_0.extremum_strict index_take linorder_not_less)
+  from xmem this have "a \<lesssim>\<^sub>l x" using above_l_def is_less_preferred_than.elims(3) rank_l.simps
+    by (metis One_nat_def Suc_le_mono add.commute add_0 add_Suc empty_iff find_index_le_size 
+        in_set_member index_def le_antisym list.set(1) size_index_conv take_0)
+  from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
+    using less_preffered_l_rel_eq by (metis)
+  from this show "x \<in> Order_Relation.above (pl_\<alpha> l) a"
+    using pref_imp_in_above by (metis)
 next
-  show "above (pl_\<alpha> l) a \<subseteq> set (above_l l a)"
-  proof clarify
-    fix x :: 'a
-    assume "x \<in> Order_Relation.above (pl_\<alpha> l) a"
-    from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
-      using pref_imp_in_above by (metis)
-    from this have alpx: "a \<lesssim>\<^sub>l x"
-      using less_preffered_l_rel_eq by (metis)
-    from this have "rank_l l x \<le> rank_l l a"
-      by auto
-    from this alpx show "x \<in> set (Preference_List.above_l l a)"
-      using Preference_List.above_l_def Preference_List.is_less_preferred_than.simps Preference_List.rank_l.simps
-      by (metis Suc_eq_plus1 Suc_le_eq in_set_member index_less_size_conv set_take_if_index)
-  qed
+  fix x :: 'a
+  assume "x \<in> Order_Relation.above (pl_\<alpha> l) a"
+  from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
+    using pref_imp_in_above by (metis)
+  from this have alpx: "a \<lesssim>\<^sub>l x"
+    using less_preffered_l_rel_eq by (metis)
+  from this have "rank_l l x \<le> rank_l l a"
+    by auto
+  from this alpx show "x \<in> set (Preference_List.above_l l a)"
+    using Preference_List.above_l_def Preference_List.is_less_preferred_than.simps Preference_List.rank_l.simps
+    by (metis Suc_eq_plus1 Suc_le_eq in_set_member index_less_size_conv set_take_if_index)
 qed
+
 
 theorem rankeq: 
   fixes A :: "'a set" and l :: "'a Preference_List" and a :: 'a
@@ -201,7 +198,7 @@ next
   qed
 next
   show "total_on A (pl_\<alpha> l)"
-    using connex_l_def lin_ord_imp_connex_l lo pl_\<alpha>_def total_on_def by fastforce
+    using lin_ord_imp_connex_l lo connex_l_def pl_\<alpha>_def total_on_def by fastforce
 qed
 
 lemma linorder_rel_imp_l: 
@@ -211,20 +208,20 @@ lemma linorder_rel_imp_l:
   unfolding linear_order_on_l_def preorder_on_l_def
 proof (clarsimp, safe)
   show "Preference_List.limited A l" unfolding pl_\<alpha>_def linear_order_on_def 
-    using assms linear_order_on_def less_preffered_l_rel_eq partial_order_onD(1) refl_on_def'
-    by (metis Preference_List.limitedI Preference_Relation.is_less_preferred_than.elims(2) case_prodD)
+    using assms limitedI linear_order_on_def less_preffered_l_rel_eq partial_order_onD(1) 
+    by (metis Preference_Relation.is_less_preferred_than.elims(2) refl_on_def' case_prodD)
 next
   show "refl_on_l A l" unfolding pl_\<alpha>_def 
     using assms refl_on_l_def Preference_Relation.lin_ord_imp_connex less_preffered_l_rel_eq
     by (metis Preference_Relation.connex_def)
 next
-  show "Preference_List.trans l" unfolding pl_\<alpha>_def
-    using Preference_List.trans_def by fastforce
+  show "Preference_List.trans l" 
+    unfolding pl_\<alpha>_def Preference_List.trans_def by fastforce
 next
   show "total_on_l A l" unfolding pl_\<alpha>_def 
-    using Preference_Relation.connex_def Preference_Relation.lin_ord_imp_connex assms 
-      total_on_l_def less_preffered_l_rel_eq
-    by (metis Preference_List.is_less_preferred_than.elims(2))   
+    using connex_def lin_ord_imp_connex assms total_on_l_def less_preffered_l_rel_eq 
+      is_less_preferred_than.elims(2)
+    by metis
 qed
 
 lemma rel_trans:
@@ -241,16 +238,9 @@ lemma connex_imp_refl:
 proof clarsimp
   fix x :: 'a
   assume "x \<in> A"
-  from this assms show "List.member pl x"
-    by (metis Preference_List.connex_l_def Preference_List.is_less_preferred_than.elims(1))
-qed  
-
-lemma aconnex:
-  fixes A :: "'a set" and pl :: "'a Preference_List"
-  assumes "well_formed_pl pl" and lo: "linear_order_on_l A pl"
-  shows "connex_l A pl"
-  using  Preference_List.connex_l_def Preference_List.is_less_preferred_than.simps 
-    linear_order_on_l_def preorder_on_l_def refl_on_l_def lo
-  by (metis nle_le)
+  from this show "List.member pl x" 
+    using assms connex_l_def is_less_preferred_than.elims(1)
+    by metis
+qed
 
 end

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Preference_List.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Preference_List.thy
@@ -1,0 +1,240 @@
+theory Preference_List
+  imports 
+    "../Preference_Relation"
+    "List-Index.List_Index"
+begin
+
+text \<open>                          
+  ordered from most to least preferred candidate
+\<close>
+
+type_synonym 'a Preference_List = "'a list"
+
+definition well_formed_pl :: "'a Preference_List \<Rightarrow> bool" where
+  "well_formed_pl pl \<equiv> distinct pl"
+
+text \<open>
+  rank 1 is top prefernce, rank 0 is not in list
+\<close>
+fun rank_l :: "'a Preference_List \<Rightarrow> 'a \<Rightarrow> nat" where
+  "rank_l cs x = (if (List.member cs x) then (index cs x) + 1 else 0)"
+
+lemma rank0_imp_notpresent:
+  "rank_l ballot x = 0 \<longrightarrow> \<not>List.member ballot x"
+  by simp
+
+fun is_less_preferred_than ::
+  "'a \<Rightarrow> 'a Preference_List \<Rightarrow> 'a \<Rightarrow> bool" ("_ \<lesssim>\<^sub>_ _" [50, 1000, 51] 50) where
+    "x \<lesssim>\<^sub>r y = ((List.member r x) \<and> (List.member r y) \<and> (rank_l r x \<ge> rank_l r y))"
+
+definition limited :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
+  "limited A r \<equiv> (\<forall> x. (List.member r x) \<longrightarrow>  x \<in> A)"
+
+fun limit_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> 'a Preference_List" where
+  "limit_l A pl =  List.filter (\<lambda> a. a \<in> A) pl"
+  
+lemma rank_gt_zero:
+  assumes
+    wf : "well_formed_pl r" and
+    refl: "x \<lesssim>\<^sub>r x"
+  shows "rank_l r x \<ge> 1"
+  using refl by simp
+
+definition total_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
+  "total_on_l A pl \<equiv> (\<forall> x \<in> A. (List.member pl x))"
+
+definition refl_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where 
+  "refl_on_l A r \<equiv> \<forall>x \<in> A. x \<lesssim>\<^sub>r x"
+
+definition trans :: "'a Preference_List \<Rightarrow> bool" where 
+  "trans r \<equiv> \<forall>(x, y, z) \<in> ((set r) \<times> (set r) \<times> (set r)).
+       x \<lesssim>\<^sub>r y \<and> y \<lesssim>\<^sub>r z \<longrightarrow> x \<lesssim>\<^sub>r z"
+
+definition preorder_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
+  "preorder_on_l A pl \<equiv> limited A pl \<and> refl_on_l A pl \<and> trans pl"
+
+definition linear_order_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
+  "linear_order_on_l A pl \<equiv> preorder_on_l A pl \<and> total_on_l A pl"
+
+definition connex_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
+  "connex_l A r \<equiv> limited A r \<and> (\<forall> x \<in> A. \<forall> y \<in> A. x \<lesssim>\<^sub>r y \<or> y \<lesssim>\<^sub>r x)"
+
+lemma lin_ord_imp_connex_l:
+  assumes "linear_order_on_l A r"
+  shows "connex_l A r"
+  by (metis Preference_List.connex_l_def Preference_List.is_less_preferred_than.simps 
+          linear_order_on_l_def preorder_on_l_def 
+          total_on_l_def assms nle_le)
+
+
+lemma limitedI:
+  "(\<And> x y. \<lbrakk> x \<lesssim>\<^sub>r y \<rbrakk> \<Longrightarrow>  x \<in> A \<and> y \<in> A) \<Longrightarrow> limited A r"
+  unfolding limited_def
+  by auto
+
+lemma limited_dest: 
+  shows "(\<And> x y. \<lbrakk> is_less_preferred_than x r y; limited A r \<rbrakk> \<Longrightarrow>  x \<in> A \<and> y \<in> A)"
+  unfolding limited_def by (simp)  
+  
+definition above_l :: "'a Preference_List \<Rightarrow> 'a \<Rightarrow> 'a Preference_List" where
+  "above_l r c \<equiv> take (rank_l r c) r"
+
+lemma above_trans:
+  assumes
+    trans: "trans r" and
+    less: "a \<lesssim>\<^sub>r b"
+  shows "set (above_l r b) \<subseteq> set (above_l r a)"
+  by (metis Preference_List.above_l_def Preference_List.is_less_preferred_than.elims(2) less set_take_subset_set_take)
+
+abbreviation ballot_on :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
+  "ballot_on A pl \<equiv> well_formed_pl pl \<and> linear_order_on_l A pl"
+
+definition pl_\<alpha> :: "'a Preference_List \<Rightarrow> 'a Preference_Relation" where
+  "pl_\<alpha> l = {(a, b). a \<lesssim>\<^sub>l b}"
+
+
+lemma less_preffered_l_rel_eq:
+  shows "a \<lesssim>\<^sub>l b \<longleftrightarrow>  Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) b"
+  by (simp add: pl_\<alpha>_def)
+
+theorem aboveeq: assumes wf: "well_formed_pl l" and lo: "linear_order_on_l A l"
+  shows "set (above_l l a) = Order_Relation.above (pl_\<alpha> l) a"
+proof
+  show "set (above_l l a) \<subseteq> above (pl_\<alpha> l) a"
+  proof clarify
+    fix x
+    assume "x \<in> set (Preference_List.above_l l a)"
+    have "length (above_l l a) = rank_l l a" unfolding above_l_def
+      by (simp add: Suc_le_eq in_set_member)
+    from wf lo this have "index l x \<le> index l a" unfolding rank_l.simps
+      by (metis Preference_List.above_l_def Preference_List.rank_l.simps Suc_eq_plus1 Suc_le_eq \<open>x \<in> set (Preference_List.above_l l a)\<close> bot_nat_0.extremum_strict index_take linorder_not_less)
+    from this have "a \<lesssim>\<^sub>l x"
+      by (metis One_nat_def Preference_List.above_l_def Preference_List.is_less_preferred_than.elims(3) Preference_List.rank_l.simps Suc_le_mono \<open>x \<in> set (Preference_List.above_l l a)\<close> add.commute add_0 add_Suc empty_iff find_index_le_size in_set_member index_def le_antisym list.set(1) size_index_conv take_0)
+    from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
+      using less_preffered_l_rel_eq by (metis)
+    from this show "x \<in> Order_Relation.above (pl_\<alpha> l) a"
+      using pref_imp_in_above by (metis)
+  qed
+next
+  show "above (pl_\<alpha> l) a \<subseteq> set (above_l l a)"
+  proof clarify
+    fix x
+    assume "x \<in> Order_Relation.above (pl_\<alpha> l) a"
+    from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
+      using pref_imp_in_above by (metis)
+    from this have alpx: "a \<lesssim>\<^sub>l x"
+      using less_preffered_l_rel_eq by (metis)
+    from this have "rank_l l x \<le> rank_l l a"
+      by auto
+    from this alpx show "x \<in> set (Preference_List.above_l l a)"
+      using Preference_List.above_l_def Preference_List.is_less_preferred_than.simps Preference_List.rank_l.simps
+      by (metis Suc_eq_plus1 Suc_le_eq in_set_member index_less_size_conv set_take_if_index)
+  qed
+qed
+
+theorem rankeq: assumes wf: "well_formed_pl l" and lo: "linear_order_on_l A l"
+  shows "rank_l l a = Preference_Relation.rank (pl_\<alpha> l) a"
+proof (simp, safe)
+  assume air: "List.member l a"
+  from assms have abe: "Order_Relation.above (pl_\<alpha> l) a = set (above_l l a)" 
+    by (simp add: aboveeq)
+  from wf have dl: "distinct (above_l l a)" unfolding well_formed_pl_def above_l_def
+    using distinct_take by blast
+  from dl have ce: "card (set (above_l l a)) = length (above_l l a)" unfolding well_formed_pl_def
+    using distinct_card
+    by blast
+  have "length (above_l l a) = rank_l l a" unfolding above_l_def
+    by (simp add: Suc_le_eq in_set_member)
+  from air abe dl ce this show "Suc (index l a) = card (Order_Relation.above (pl_\<alpha> l) a)"
+    by simp
+next
+  assume anr: "\<not> List.member l a"
+  from anr have "a \<notin> (set l)" unfolding pl_\<alpha>_def
+    by (simp add: in_set_member) 
+  from this have "a \<notin> Order_Relation.above (pl_\<alpha> l) a" 
+      unfolding Order_Relation.above_def pl_\<alpha>_def
+      by (simp add: anr)
+  from this have "Order_Relation.above (pl_\<alpha> l) a = {}" 
+      unfolding Order_Relation.above_def
+      using anr less_preffered_l_rel_eq by fastforce
+  from this show "card (Order_Relation.above (pl_\<alpha> l) a) = 0" by fastforce
+qed
+
+theorem linorder_l_imp_rel:
+  assumes wf: "well_formed_pl l" and lo: "linear_order_on_l A l"
+  shows "Order_Relation.linear_order_on A (pl_\<alpha> l)"
+proof (unfold Order_Relation.linear_order_on_def partial_order_on_def 
+    Order_Relation.preorder_on_def, clarsimp, safe)
+  from lo have "refl_on_l A l" 
+    by (unfold linear_order_on_l_def preorder_on_l_def, simp)
+  from this show "refl_on A (pl_\<alpha> l)" 
+  proof (unfold refl_on_l_def pl_\<alpha>_def refl_on_def, clarsimp)
+    fix a and b
+    assume ni: "\<forall>x\<in>A. List.member l x"
+    assume aA: "List.member l a" and bA: "List.member l b"
+    from ni aA bA show "a \<in> A \<and> b \<in> A"
+      using lo linear_order_on_l_def preorder_on_l_def Preference_List.limited_def by (metis)
+  qed
+next
+  show "Relation.trans (pl_\<alpha> l)"
+    by (unfold Preference_List.trans_def pl_\<alpha>_def Relation.trans_def, simp)
+next
+  show "antisym (pl_\<alpha> l)"
+  proof (unfold antisym_def pl_\<alpha>_def is_less_preferred_than.simps, clarsimp)
+    fix x and y 
+    assume xm: "List.member l x" and ym: "List.member l y"
+    assume si: "index l x = index l y"
+    from xm ym si show "x = y"
+      by (simp add: member_def)
+  qed
+next
+  show "total_on A (pl_\<alpha> l)"
+    using connex_l_def lin_ord_imp_connex_l lo pl_\<alpha>_def total_on_def by fastforce
+qed
+
+lemma linorder_rel_imp_l: 
+  assumes "Order_Relation.linear_order_on A (pl_\<alpha> l)"
+  shows "linear_order_on_l A l"
+  unfolding linear_order_on_l_def preorder_on_l_def
+proof (clarsimp, safe)
+  show "Preference_List.limited A l" unfolding pl_\<alpha>_def linear_order_on_def 
+    using assms linear_order_on_def less_preffered_l_rel_eq partial_order_onD(1) refl_on_def'
+    by (metis Preference_List.limitedI Preference_Relation.is_less_preferred_than.elims(2) case_prodD)
+next
+  show "refl_on_l A l" unfolding pl_\<alpha>_def 
+    using assms refl_on_l_def Preference_Relation.lin_ord_imp_connex less_preffered_l_rel_eq
+    by (metis Preference_Relation.connex_def)
+next
+  show "Preference_List.trans l" unfolding pl_\<alpha>_def
+    using Preference_List.trans_def by fastforce
+next
+  show "total_on_l A l" unfolding pl_\<alpha>_def 
+    using Preference_Relation.connex_def Preference_Relation.lin_ord_imp_connex assms 
+      total_on_l_def less_preffered_l_rel_eq
+    by (metis Preference_List.is_less_preferred_than.elims(2))   
+qed
+
+lemma rel_trans:
+  shows "Relation.trans (pl_\<alpha> pl)"
+  unfolding Relation.trans_def pl_\<alpha>_def
+  by auto
+
+lemma connex_imp_refl:
+  assumes "connex_l A pl"
+  shows "refl_on_l A pl"
+  unfolding connex_l_def refl_on_l_def
+proof clarsimp
+  fix x
+  assume "x \<in> A"
+  from this assms show "List.member pl x"
+    by (metis Preference_List.connex_l_def Preference_List.is_less_preferred_than.elims(1))
+qed  
+
+lemma aconnex:
+  assumes "well_formed_pl pl" and lo: "linear_order_on_l A pl"
+  shows "connex_l A pl"
+  using  Preference_List.connex_l_def Preference_List.is_less_preferred_than.simps 
+    linear_order_on_l_def preorder_on_l_def refl_on_l_def lo
+  by (metis nle_le)
+
+end

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Preference_List.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Preference_List.thy
@@ -1,46 +1,107 @@
+(*  File:       Preference_List.thy
+    Copyright   2023  Karlsruhe Institute of Technology (KIT)
+*)
+\<^marker>\<open>creator "Valentin Springsklee, Karlsruhe Institute of Technology (KIT)"\<close>
+
+section \<open>Preference List\<close>
+
 theory Preference_List
-  imports 
-    "../Preference_Relation"
-    "List-Index.List_Index"
+  imports "../Preference_Relation"
+          "List-Index.List_Index"
 begin
 
-text \<open>                          
-  ordered from most to least preferred candidate
+text \<open>
+  Preference lists derive from preference relations, ordered from most to
+  least preferred alternative.
 \<close>
+
+subsection \<open>Well-Formedness\<close>
 
 type_synonym 'a Preference_List = "'a list"
 
-definition well_formed_pl :: "'a Preference_List \<Rightarrow> bool" where
-  "well_formed_pl pl \<equiv> distinct pl"
+abbreviation well_formed_l :: "'a Preference_List \<Rightarrow> bool" where
+  "well_formed_l p \<equiv> distinct p"
+
+subsection \<open>Ranking\<close>
 
 text \<open>
-  rank 1 is top prefernce, rank 0 is not in list
+  Rank 1 is the top preference, rank 2 the second, and so on. Rank 0 does not exist.
 \<close>
+
 fun rank_l :: "'a Preference_List \<Rightarrow> 'a \<Rightarrow> nat" where
-  "rank_l cs x = (if (List.member cs x) then (index cs x) + 1 else 0)"
+  "rank_l l x = (if (List.member l x) then (index l x) + 1 else 0)"
 
-lemma rank0_imp_notpresent:
-  fixes ballot :: "'a Preference_List"
-  shows "rank_l ballot x = 0 \<longrightarrow> \<not>List.member ballot x"
-  by simp
+definition above_l :: "'a Preference_List \<Rightarrow> 'a \<Rightarrow> 'a Preference_List" where
+  "above_l r c \<equiv> take (rank_l r c) r"
 
-fun is_less_preferred_than ::
+lemma rank_zero_imp_not_present:
+  fixes
+    p :: "'a Preference_List" and
+    a :: "'a"
+  assumes "rank_l p a = 0"
+  shows "\<not> List.member p a"
+  using assms
+  by force
+
+subsection \<open>Definition\<close>
+
+fun is_less_preferred_than_l ::
   "'a \<Rightarrow> 'a Preference_List \<Rightarrow> 'a \<Rightarrow> bool" ("_ \<lesssim>\<^sub>_ _" [50, 1000, 51] 50) where
     "x \<lesssim>\<^sub>l y = ((List.member l x) \<and> (List.member l y) \<and> (rank_l l x \<ge> rank_l l y))"
+ 
+lemma rank_gt_zero:
+  fixes
+    l :: "'a Preference_List" and
+    x :: 'a
+  assumes
+    wf : "well_formed_l l" and
+    refl: "x \<lesssim>\<^sub>l x"
+  shows "rank_l l x \<ge> 1"
+  using refl
+  by simp
+
+definition pl_\<alpha> :: "'a Preference_List \<Rightarrow> 'a Preference_Relation" where
+  "pl_\<alpha> l = {(a, b). a \<lesssim>\<^sub>l b}"
+
+lemma rel_trans:
+  fixes l :: "'a Preference_List"
+  shows "Relation.trans (pl_\<alpha> l)"
+  unfolding Relation.trans_def pl_\<alpha>_def
+  by simp
+
+subsection \<open>Limited Preference\<close>
 
 definition limited :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
   "limited A r \<equiv> (\<forall> x. (List.member r x) \<longrightarrow>  x \<in> A)"
 
 fun limit_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> 'a Preference_List" where
   "limit_l A pl =  List.filter (\<lambda> a. a \<in> A) pl"
-  
-lemma rank_gt_zero:
-  fixes l :: "'a Preference_List" and x :: 'a
+
+lemma limitedI:
+  fixes
+    l :: "'a Preference_List" and
+    A :: "'a set"
+  assumes "\<And> x y. x \<lesssim>\<^sub>l y \<Longrightarrow> x \<in> A \<and> y \<in> A"
+  shows "limited A l"
+  using assms
+  unfolding limited_def
+  by auto
+
+lemma limited_dest:
+  fixes
+    A :: "'a set" and
+    l :: "'a Preference_List" and
+    x :: "'a" and
+    y :: "'a"
   assumes
-    wf : "well_formed_pl l" and
-    refl: "x \<lesssim>\<^sub>l x"
-  shows "rank_l l x \<ge> 1"
-  using refl by simp
+    "is_less_preferred_than_l x l y" and
+    "limited A l"
+  shows "x \<in> A \<and> y \<in> A"
+  using assms
+  unfolding limited_def
+  by simp
+
+subsection \<open>Auxiliary Definitions\<close>
 
 definition total_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
   "total_on_l A pl \<equiv> (\<forall> x \<in> A. (List.member pl x))"
@@ -49,8 +110,7 @@ definition refl_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> b
   "refl_on_l A r \<equiv> \<forall>x \<in> A. x \<lesssim>\<^sub>r x"
 
 definition trans :: "'a Preference_List \<Rightarrow> bool" where 
-  "trans l \<equiv> \<forall>(x, y, z) \<in> ((set l) \<times> (set l) \<times> (set l)).
-       x \<lesssim>\<^sub>l y \<and> y \<lesssim>\<^sub>l z \<longrightarrow> x \<lesssim>\<^sub>l z"
+  "trans l \<equiv> \<forall> (x, y, z) \<in> ((set l) \<times> (set l) \<times> (set l)). x \<lesssim>\<^sub>l y \<and> y \<lesssim>\<^sub>l z \<longrightarrow> x \<lesssim>\<^sub>l z"
 
 definition preorder_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
   "preorder_on_l A pl \<equiv> limited A pl \<and> refl_on_l A pl \<and> trans pl"
@@ -61,185 +121,224 @@ definition linear_order_on_l :: "'a set \<Rightarrow> 'a Preference_List \<Right
 definition connex_l :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
   "connex_l A r \<equiv> limited A r \<and> (\<forall> x \<in> A. \<forall> y \<in> A. x \<lesssim>\<^sub>r y \<or> y \<lesssim>\<^sub>r x)"
 
+abbreviation ballot_on :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
+  "ballot_on A pl \<equiv> well_formed_l pl \<and> linear_order_on_l A pl"
+
+subsection \<open>Auxiliary Lemmas\<close>
+
+lemma connex_imp_refl:
+  fixes
+    A :: "'a set" and
+    l :: "'a Preference_List"
+  assumes "connex_l A l"
+  shows "refl_on_l A l"
+  unfolding connex_l_def refl_on_l_def
+  using assms connex_l_def
+  by metis
+
 lemma lin_ord_imp_connex_l:
-  fixes A :: "'a set" and l :: "'a Preference_List"
+  fixes
+    A :: "'a set" and
+    r :: "'a Preference_List"
   assumes "linear_order_on_l A r"
   shows "connex_l A r"
-  by (metis Preference_List.connex_l_def Preference_List.is_less_preferred_than.simps 
-          linear_order_on_l_def preorder_on_l_def 
-          total_on_l_def assms nle_le)
-
-
-lemma limitedI:
-  fixes l :: "'a Preference_List"
-  shows "(\<And> x y. \<lbrakk> x \<lesssim>\<^sub>l y \<rbrakk> \<Longrightarrow>  x \<in> A \<and> y \<in> A) \<Longrightarrow> limited A l"
-  unfolding limited_def
-  by auto
-
-lemma limited_dest: 
-  fixes A :: "'a set" and l :: "'a Preference_List" and a :: 'a
-  shows "(\<And> x y. \<lbrakk> is_less_preferred_than x l y; limited A l \<rbrakk> \<Longrightarrow>  x \<in> A \<and> y \<in> A)"
-  unfolding limited_def by (simp)  
-  
-definition above_l :: "'a Preference_List \<Rightarrow> 'a \<Rightarrow> 'a Preference_List" where
-  "above_l r c \<equiv> take (rank_l r c) r"
+  using assms Preference_List.connex_l_def is_less_preferred_than_l.simps
+        linear_order_on_l_def preorder_on_l_def total_on_l_def assms nle_le
+  by metis
 
 lemma above_trans:
-  fixes l :: "'a Preference_List" and a :: 'a and b :: 'a
+  fixes
+    l :: "'a Preference_List" and
+    a :: 'a and
+    b :: 'a
   assumes
     trans: "trans l" and
     less: "a \<lesssim>\<^sub>l b"
   shows "set (above_l l b) \<subseteq> set (above_l l a)"
-  by (metis Preference_List.above_l_def Preference_List.is_less_preferred_than.elims(2) less set_take_subset_set_take)
+  using assms above_l_def set_take_subset_set_take
+  unfolding Preference_List.is_less_preferred_than_l.simps
+  by metis
 
-abbreviation ballot_on :: "'a set \<Rightarrow> 'a Preference_List \<Rightarrow> bool" where
-  "ballot_on A pl \<equiv> well_formed_pl pl \<and> linear_order_on_l A pl"
+lemma less_preferred_l_rel_eq:
+  fixes
+    l :: "'a Preference_List" and
+    a :: 'a and
+    b :: 'a
+  shows "a \<lesssim>\<^sub>l b = Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) b"
+  unfolding pl_\<alpha>_def
+  by simp
 
-definition pl_\<alpha> :: "'a Preference_List \<Rightarrow> 'a Preference_Relation" where
-  "pl_\<alpha> l = {(a, b). a \<lesssim>\<^sub>l b}"
-
-
-lemma less_preffered_l_rel_eq:
-  fixes l :: "'a Preference_List" and a :: 'a and b :: 'a
-  shows "a \<lesssim>\<^sub>l b \<longleftrightarrow>  Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) b"
-  by (simp add: pl_\<alpha>_def)
-
-theorem aboveeq: 
-  fixes A :: "'a set" and l :: "'a Preference_List" and a :: 'a
-  assumes wf: "well_formed_pl l" and lo: "linear_order_on_l A l"
+theorem above_eq:
+  fixes
+    A :: "'a set" and
+    l :: "'a Preference_List" and
+    a :: 'a
+  assumes
+    wf: "well_formed_l l" and
+    lin_ord: "linear_order_on_l A l"
   shows "set (above_l l a) = Order_Relation.above (pl_\<alpha> l) a"
-proof safe
-  fix x :: 'a
-  assume xmem: "x \<in> set (Preference_List.above_l l a)"
-  have "length (above_l l a) = rank_l l a" unfolding above_l_def
-    by (simp add: Suc_le_eq in_set_member)
-  from xmem wf lo this have "index l x \<le> index l a" unfolding rank_l.simps using above_l_def
-    by (metis  Preference_List.rank_l.simps Suc_eq_plus1 
-        Suc_le_eq bot_nat_0.extremum_strict index_take linorder_not_less)
-  from xmem this have "a \<lesssim>\<^sub>l x" using above_l_def is_less_preferred_than.elims(3) rank_l.simps
-    by (metis One_nat_def Suc_le_mono add.commute add_0 add_Suc empty_iff find_index_le_size 
-        in_set_member index_def le_antisym list.set(1) size_index_conv take_0)
-  from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
-    using less_preffered_l_rel_eq by (metis)
-  from this show "x \<in> Order_Relation.above (pl_\<alpha> l) a"
-    using pref_imp_in_above by (metis)
+proof (safe)
+  fix b :: "'a"
+  assume b_member: "b \<in> set (Preference_List.above_l l a)"
+  have "length (above_l l a) = rank_l l a"
+    unfolding above_l_def
+    using Suc_le_eq
+    by (simp add: in_set_member)
+  with b_member wf lin_ord
+  have "index l b \<le> index l a"
+    unfolding rank_l.simps
+    using above_l_def Preference_List.rank_l.simps Suc_eq_plus1 Suc_le_eq
+          bot_nat_0.extremum_strict index_take linorder_not_less
+    by metis
+  with b_member
+  have "a \<lesssim>\<^sub>l b"
+    using above_l_def is_less_preferred_than_l.elims(3) rank_l.simps One_nat_def
+          Suc_le_mono add.commute add_0 add_Suc empty_iff find_index_le_size 
+        in_set_member index_def le_antisym list.set(1) size_index_conv take_0
+    by metis
+  hence "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) b"
+    using less_preferred_l_rel_eq
+    by metis
+  thus "b \<in> Order_Relation.above (pl_\<alpha> l) a"
+    using pref_imp_in_above
+    by metis
 next
-  fix x :: 'a
-  assume "x \<in> Order_Relation.above (pl_\<alpha> l) a"
-  from this have "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) x"
-    using pref_imp_in_above by (metis)
-  from this have alpx: "a \<lesssim>\<^sub>l x"
-    using less_preffered_l_rel_eq by (metis)
-  from this have "rank_l l x \<le> rank_l l a"
+  fix b :: "'a"
+  assume "b \<in> Order_Relation.above (pl_\<alpha> l) a"
+  hence "Preference_Relation.is_less_preferred_than a (pl_\<alpha> l) b"
+    using pref_imp_in_above
+    by metis
+  hence a_less_pref_than_b: "a \<lesssim>\<^sub>l b"
+    using less_preferred_l_rel_eq
+    by metis
+  hence "rank_l l b \<le> rank_l l a"
     by auto
-  from this alpx show "x \<in> set (Preference_List.above_l l a)"
-    using Preference_List.above_l_def Preference_List.is_less_preferred_than.simps Preference_List.rank_l.simps
-    by (metis Suc_eq_plus1 Suc_le_eq in_set_member index_less_size_conv set_take_if_index)
+  with a_less_pref_than_b
+  show "b \<in> set (Preference_List.above_l l a)"
+    unfolding Preference_List.above_l_def Preference_List.is_less_preferred_than_l.simps
+              Preference_List.rank_l.simps
+    using Suc_eq_plus1 Suc_le_eq in_set_member index_less_size_conv set_take_if_index
+    by (metis (full_types))
 qed
 
-
-theorem rankeq: 
-  fixes A :: "'a set" and l :: "'a Preference_List" and a :: 'a
-  assumes wf: "well_formed_pl l" and lo: "linear_order_on_l A l"
+theorem rank_eq:
+  fixes
+    A :: "'a set" and
+    l :: "'a Preference_List" and
+    a :: 'a
+  assumes
+    wf: "well_formed_l l" and
+    lin_ord: "linear_order_on_l A l"
   shows "rank_l l a = Preference_Relation.rank (pl_\<alpha> l) a"
 proof (simp, safe)
-  assume air: "List.member l a"
-  from assms have abe: "Order_Relation.above (pl_\<alpha> l) a = set (above_l l a)" 
-    by (simp add: aboveeq)
-  from wf have dl: "distinct (above_l l a)" unfolding well_formed_pl_def above_l_def
-    using distinct_take by blast
-  from dl have ce: "card (set (above_l l a)) = length (above_l l a)" unfolding well_formed_pl_def
-    using distinct_card
+  assume a_in_l: "List.member l a"
+  have above_presv_rel: "Order_Relation.above (pl_\<alpha> l) a = set (above_l l a)"
+    using wf lin_ord
+    by (simp add: above_eq)
+  have dist_l: "distinct (above_l l a)"
+    unfolding above_l_def
+    using wf distinct_take
     by blast
-  have "length (above_l l a) = rank_l l a" unfolding above_l_def
+  have above_presv_card: "card (set (above_l l a)) = length (above_l l a)"
+    using dist_l distinct_card
+    by blast
+  have "length (above_l l a) = rank_l l a"
+    unfolding above_l_def
     by (simp add: Suc_le_eq in_set_member)
-  from air abe dl ce this show "Suc (index l a) = card (Order_Relation.above (pl_\<alpha> l) a)"
+  with a_in_l above_presv_rel dist_l above_presv_card
+  show "Suc (index l a) = card (Order_Relation.above (pl_\<alpha> l) a)"
     by simp
 next
-  assume anr: "\<not> List.member l a"
-  from anr have "a \<notin> (set l)" unfolding pl_\<alpha>_def
-    by (simp add: in_set_member) 
-  from this have "a \<notin> Order_Relation.above (pl_\<alpha> l) a" 
-      unfolding Order_Relation.above_def pl_\<alpha>_def
-      by (simp add: anr)
-  from this have "Order_Relation.above (pl_\<alpha> l) a = {}" 
-      unfolding Order_Relation.above_def
-      using anr less_preffered_l_rel_eq by fastforce
-  from this show "card (Order_Relation.above (pl_\<alpha> l) a) = 0" by fastforce
+  assume a_not_in_l: "\<not> List.member l a"
+  hence "a \<notin> (set l)"
+    unfolding pl_\<alpha>_def in_set_member
+    by simp 
+  hence "a \<notin> Order_Relation.above (pl_\<alpha> l) a" 
+    unfolding Order_Relation.above_def pl_\<alpha>_def
+    using a_not_in_l
+    by simp
+  hence "Order_Relation.above (pl_\<alpha> l) a = {}" 
+    unfolding Order_Relation.above_def
+    using a_not_in_l less_preferred_l_rel_eq
+    by fastforce
+  thus "card (Order_Relation.above (pl_\<alpha> l) a) = 0"
+    by fastforce
 qed
 
-theorem linorder_l_imp_rel:
-  fixes l :: "'a Preference_List"
-  assumes wf: "well_formed_pl l" and lo: "linear_order_on_l A l"
+theorem lin_ord_l_imp_rel:
+  fixes
+    A :: "'a set" and
+    l :: "'a Preference_List"
+  assumes
+    wf: "well_formed_l l" and
+    lin_ord: "linear_order_on_l A l"
   shows "Order_Relation.linear_order_on A (pl_\<alpha> l)"
 proof (unfold Order_Relation.linear_order_on_def partial_order_on_def 
-    Order_Relation.preorder_on_def, clarsimp, safe)
-  from lo have "refl_on_l A l" 
-    by (unfold linear_order_on_l_def preorder_on_l_def, simp)
-  from this show "refl_on A (pl_\<alpha> l)" 
-  proof (unfold refl_on_l_def pl_\<alpha>_def refl_on_def, clarsimp)
-    fix a :: 'a  and b :: 'a
-    assume ni: "\<forall>x\<in>A. List.member l x"
-    assume aA: "List.member l a" and bA: "List.member l b"
-    from ni aA bA show "a \<in> A \<and> b \<in> A"
-      using lo linear_order_on_l_def preorder_on_l_def Preference_List.limited_def by (metis)
-  qed
+       Order_Relation.preorder_on_def, clarsimp, safe)
+  have "refl_on_l A l"
+    using lin_ord
+    unfolding linear_order_on_l_def preorder_on_l_def
+    by simp
+  thus "refl_on A (pl_\<alpha> l)"
+    using lin_ord
+    unfolding refl_on_l_def pl_\<alpha>_def refl_on_def linear_order_on_l_def
+              preorder_on_l_def Preference_List.limited_def
+    by fastforce
 next
   show "Relation.trans (pl_\<alpha> l)"
-    by (unfold Preference_List.trans_def pl_\<alpha>_def Relation.trans_def, simp)
+    unfolding Preference_List.trans_def pl_\<alpha>_def Relation.trans_def
+    by simp
 next
   show "antisym (pl_\<alpha> l)"
   proof (unfold antisym_def pl_\<alpha>_def is_less_preferred_than.simps, clarsimp)
-    fix x :: 'a  and y :: 'a 
-    assume xm: "List.member l x" and ym: "List.member l y"
-    assume si: "index l x = index l y"
-    from xm ym si show "x = y"
-      by (simp add: member_def)
+    fix
+      a :: "'a" and
+      b :: "'a"
+    assume
+      "List.member l a" and
+      "index l a = index l b"
+    thus "a = b"
+      unfolding member_def
+      by simp
   qed
 next
-  show "total_on A (pl_\<alpha> l)"
-    using lin_ord_imp_connex_l lo connex_l_def pl_\<alpha>_def total_on_def by fastforce
+  have "linear_order_on_l A l \<longrightarrow> connex_l A l"
+    by (simp add: lin_ord_imp_connex_l)
+  hence "connex_l A l"
+    using lin_ord
+    by metis
+  thus "total_on A (pl_\<alpha> l)"
+    unfolding connex_l_def pl_\<alpha>_def total_on_def
+    by simp
 qed
 
-lemma linorder_rel_imp_l: 
-  fixes A :: "'a set" and l :: "'a Preference_List"
+lemma lin_ord_rel_imp_l: 
+  fixes
+    A :: "'a set" and
+    l :: "'a Preference_List"
   assumes "Order_Relation.linear_order_on A (pl_\<alpha> l)"
   shows "linear_order_on_l A l"
-  unfolding linear_order_on_l_def preorder_on_l_def
-proof (clarsimp, safe)
-  show "Preference_List.limited A l" unfolding pl_\<alpha>_def linear_order_on_def 
-    using assms limitedI linear_order_on_def less_preffered_l_rel_eq partial_order_onD(1) 
-    by (metis Preference_Relation.is_less_preferred_than.elims(2) refl_on_def' case_prodD)
+proof (unfold linear_order_on_l_def preorder_on_l_def, clarsimp, safe)
+  show "Preference_List.limited A l"
+    unfolding pl_\<alpha>_def linear_order_on_def 
+    using assms limitedI linear_order_on_def less_preferred_l_rel_eq partial_order_onD(1)
+          Preference_Relation.is_less_preferred_than.elims(2) refl_on_def' case_prodD
+    by metis
 next
-  show "refl_on_l A l" unfolding pl_\<alpha>_def 
-    using assms refl_on_l_def Preference_Relation.lin_ord_imp_connex less_preffered_l_rel_eq
-    by (metis Preference_Relation.connex_def)
+  show "refl_on_l A l"
+    unfolding pl_\<alpha>_def refl_on_l_def
+    using assms Preference_Relation.lin_ord_imp_connex less_preferred_l_rel_eq
+          Preference_Relation.connex_def
+    by metis
 next
   show "Preference_List.trans l" 
-    unfolding pl_\<alpha>_def Preference_List.trans_def by fastforce
+    unfolding pl_\<alpha>_def Preference_List.trans_def
+    by fastforce
 next
-  show "total_on_l A l" unfolding pl_\<alpha>_def 
-    using connex_def lin_ord_imp_connex assms total_on_l_def less_preffered_l_rel_eq 
-      is_less_preferred_than.elims(2)
-    by metis
-qed
-
-lemma rel_trans:
-  fixes pl :: "'a Preference_List"
-  shows "Relation.trans (pl_\<alpha> pl)"
-  unfolding Relation.trans_def pl_\<alpha>_def
-  by auto
-
-lemma connex_imp_refl:
-  fixes A :: "'a set" and pl :: "'a Preference_List"
-  assumes "connex_l A pl"
-  shows "refl_on_l A pl"
-  unfolding connex_l_def refl_on_l_def
-proof clarsimp
-  fix x :: 'a
-  assume "x \<in> A"
-  from this show "List.member pl x" 
-    using assms connex_l_def is_less_preferred_than.elims(1)
+  show "total_on_l A l"
+    unfolding pl_\<alpha>_def 
+    using connex_def lin_ord_imp_connex assms total_on_l_def less_preferred_l_rel_eq 
+      is_less_preferred_than_l.elims(2)
     by metis
 qed
 

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
@@ -12,7 +12,6 @@ fun pl_to_pr_\<alpha> :: "'a Profile_List \<Rightarrow> 'a Profile" where
 lemma length_preserving:
   fixes pr:: "'a Profile_List"
   shows "length pl = length (pl_to_pr_\<alpha> pl)"
-  unfolding pl_to_pr_\<alpha>.simps
   by simp
 
 definition profile_l :: "'a set \<Rightarrow> 'a Profile_List \<Rightarrow> bool" where
@@ -21,6 +20,7 @@ definition profile_l :: "'a set \<Rightarrow> 'a Profile_List \<Rightarrow> bool
 lemma profile_prop_refine:
   (* Refinement Framework syntax*)
   (*assumes "(pl,pr)\<in>br pl_to_pr_\<alpha> (profile_l A)"*)
+  fixes A :: "'a set" and pl :: "'a Profile_List"
   assumes "profile_l A pl"
   shows "profile A (pl_to_pr_\<alpha> pl)"
   unfolding profile_def

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
@@ -1,0 +1,41 @@
+theory Profile_List
+  imports "../Profile" 
+    Preference_List
+begin
+
+type_synonym 'a Profile_List = "('a Preference_List) list"
+
+text \<open> Abstraction from Profile List to Profile \<close>
+fun pl_to_pr_\<alpha> :: "'a Profile_List \<Rightarrow> 'a Profile" where
+  "pl_to_pr_\<alpha> pl = map (Preference_List.pl_\<alpha>) pl"
+
+lemma length_preserving:
+  fixes pr:: "'a Profile_List"
+  shows "length pl = length (pl_to_pr_\<alpha> pl)"
+  unfolding pl_to_pr_\<alpha>.simps
+  by simp
+
+definition profile_l :: "'a set \<Rightarrow> 'a Profile_List \<Rightarrow> bool" where
+  "profile_l A pl \<equiv> (\<forall> i < length pl. ballot_on A (pl!i))"
+
+lemma profile_prop_refine:
+  (* Refinement Framework syntax*)
+  (*assumes "(pl,pr)\<in>br pl_to_pr_\<alpha> (profile_l A)"*)
+  assumes "profile_l A pl"
+  shows "profile A (pl_to_pr_\<alpha> pl)"
+  unfolding profile_def
+  apply(intro allI impI)
+proof (-)
+  fix i
+  assume ir: "i < length (pl_to_pr_\<alpha> pl)"
+  from ir assms have wf: "well_formed_pl (pl ! i)" unfolding profile_l_def
+    by (simp)
+  from ir assms have "linear_order_on_l A (pl ! i)" unfolding profile_l_def
+    by (simp) 
+  from wf assms this show "linear_order_on A ((pl_to_pr_\<alpha> pl) ! i)"
+    using linorder_l_imp_rel
+    by (metis (mono_tags, lifting) ir length_map nth_map pl_to_pr_\<alpha>.simps)
+qed
+
+
+end

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
@@ -1,41 +1,64 @@
+(*  File:       Profile_List.thy
+    Copyright   2023  Karlsruhe Institute of Technology (KIT)
+*)
+\<^marker>\<open>creator "Valentin Springsklee, Karlsruhe Institute of Technology (KIT)"\<close>
+
+section \<open>Preference (List) Profile\<close>
+
 theory Profile_List
   imports "../Profile" 
-    Preference_List
-
+          Preference_List
 begin
+
+subsection \<open>Definition\<close>
+
+text \<open>
+  A profile (list) contains one ballot for each voter.
+\<close>
 
 type_synonym 'a Profile_List = "('a Preference_List) list"
 
-text \<open> Abstraction from Profile List to Profile \<close>
+text \<open>
+  Abstraction from profile list to profile.
+\<close>
+
 fun pl_to_pr_\<alpha> :: "'a Profile_List \<Rightarrow> 'a Profile" where
   "pl_to_pr_\<alpha> pl = map (Preference_List.pl_\<alpha>) pl"
 
-lemma length_preserving:
-  fixes pr:: "'a Profile_List"
-  shows "length pl = length (pl_to_pr_\<alpha> pl)"
+lemma prof_abstr_presv_size:
+  fixes p :: "'a Profile_List"
+  shows "length p = length (pl_to_pr_\<alpha> p)"
   by simp
 
+text \<open>
+  A profile on a finite set of alternatives A contains only ballots that are
+  lists of linear orders on A.
+\<close>
+
 definition profile_l :: "'a set \<Rightarrow> 'a Profile_List \<Rightarrow> bool" where
-  "profile_l A pl \<equiv> (\<forall> i < length pl. ballot_on A (pl!i))"
+  "profile_l A p \<equiv> (\<forall> i < length p. ballot_on A (p!i))"
 
-lemma profile_prop_refine:
-  (* Refinement Framework syntax*)
-  (*assumes "(pl,pr)\<in>br pl_to_pr_\<alpha> (profile_l A)"*)
-  fixes A :: "'a set" and pl :: "'a Profile_List"
-  assumes "profile_l A pl"
-  shows "profile A (pl_to_pr_\<alpha> pl)"
-  unfolding profile_def
-  apply(intro allI impI)
-proof (-)
-  fix i
-  assume ir: "i < length (pl_to_pr_\<alpha> pl)"
-  from ir assms have wf: "well_formed_pl (pl ! i)" unfolding profile_l_def
-    by (simp)
-  from ir assms have "linear_order_on_l A (pl ! i)" unfolding profile_l_def
-    by (simp) 
-  from wf assms this show "linear_order_on A ((pl_to_pr_\<alpha> pl) ! i)"
-    by (metis linorder_l_imp_rel ir length_map nth_map pl_to_pr_\<alpha>.simps)
+lemma refinement:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile_List"
+  assumes "profile_l A p"
+  shows "profile A (pl_to_pr_\<alpha> p)"
+proof (unfold profile_def, intro allI impI)
+  fix i :: nat
+  assume ir: "i < length (pl_to_pr_\<alpha> p)"
+  from ir assms
+  have wf: "well_formed_l (p!i)"
+    unfolding profile_l_def
+    by simp
+  from ir assms
+  have "linear_order_on_l A (p!i)"
+  unfolding profile_l_def
+    by simp
+  with wf assms
+  show "linear_order_on A ((pl_to_pr_\<alpha> p)!i)"
+    using lin_ord_l_imp_rel ir length_map nth_map pl_to_pr_\<alpha>.simps
+    by metis
 qed
-
 
 end

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List.thy
@@ -1,6 +1,7 @@
 theory Profile_List
   imports "../Profile" 
     Preference_List
+
 begin
 
 type_synonym 'a Profile_List = "('a Preference_List) list"
@@ -33,8 +34,7 @@ proof (-)
   from ir assms have "linear_order_on_l A (pl ! i)" unfolding profile_l_def
     by (simp) 
   from wf assms this show "linear_order_on A ((pl_to_pr_\<alpha> pl) ! i)"
-    using linorder_l_imp_rel
-    by (metis (mono_tags, lifting) ir length_map nth_map pl_to_pr_\<alpha>.simps)
+    by (metis linorder_l_imp_rel ir length_map nth_map pl_to_pr_\<alpha>.simps)
 qed
 
 

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Result.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Result.thy
@@ -64,116 +64,124 @@ abbreviation reject_r :: "'a Result \<Rightarrow> 'a set" where
 abbreviation defer_r :: "'a Result \<Rightarrow> 'a set" where
   "defer_r r \<equiv> snd (snd r)"
 
-subsection \<open>Auxiliary Lemmata\<close>
+subsection \<open>Auxiliary Lemmas\<close>
 
 lemma result_imp_rej:
+  fixes
+    A :: "'a set" and
+    e :: "'a set" and
+    r :: "'a set" and
+    d :: "'a set"
   assumes "well_formed A (e, r, d)"
   shows "A - (e \<union> d) = r"
 proof (safe)
-  fix x :: "'a"
+  fix a :: "'a"
   assume
-    x_in_A: "x \<in> A" and
-    x_not_rej: "x \<notin> r" and
-    x_not_def: "x \<notin> d"
-  from assms have
-    "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and>
-    (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
+    a_in_A: "a \<in> A" and
+    a_not_rej: "a \<notin> r" and
+    a_not_def: "a \<notin> d"
+  from assms
+  have "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and> (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
     by simp
-  thus "x \<in> e"
-    using x_in_A x_not_rej x_not_def
+  thus "a \<in> e"
+    using a_in_A a_not_rej a_not_def
     by auto
 next
-  fix x :: "'a"
-  assume x_rej: "x \<in> r"
-  from assms have
-    "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and>
-    (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
+  fix a :: "'a"
+  assume a_rej: "a \<in> r"
+  from assms
+  have "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and> (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
     by simp
-  thus "x \<in> A"
-    using x_rej
+  thus "a \<in> A"
+    using a_rej
     by auto
 next
-  fix x :: "'a"
+  fix a :: "'a"
   assume
-    x_rej:  "x \<in> r" and
-    x_elec: "x \<in> e"
-  from assms have
-    "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and>
-    (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
+    a_rej:  "a \<in> r" and
+    a_elec: "a \<in> e"
+  from assms
+  have "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and> (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
     by simp
   thus False
-    using x_rej x_elec
+    using a_rej a_elec
     by auto
 next
-  fix x :: "'a"
+  fix a :: "'a"
   assume
-    x_rej: "x \<in> r" and
-    x_def: "x \<in> d"
-  from assms have
-    "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and>
-    (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
+    a_rej: "a \<in> r" and
+    a_def: "a \<in> d"
+  have "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and> (r \<inter> d = {}) \<and> (e \<union> r \<union> d = A)"
+    using assms
     by simp
   thus False
-    using x_rej x_def
+    using a_rej a_def
     by auto
 qed
 
 lemma result_count:
+  fixes
+    A :: "'a set" and
+    e :: "'a set" and
+    r :: "'a set" and
+    d :: "'a set"
   assumes
     wf: "well_formed A (e, r, d)" and
     fin_A: "finite A"
   shows "card A = card e + card r + card d"
 proof -
-  from wf have disj:
-    "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and> (r \<inter> d = {})"
+  have set_partit: "e \<union> r \<union> d = A"
+    using wf
     by simp
-  from wf have set_partit:
-    "e \<union> r \<union> d = A"
+  have "(e \<inter> r = {}) \<and> (e \<inter> d = {}) \<and> (r \<inter> d = {})"
+    using wf
     by simp
-  show ?thesis
-    using fin_A disj set_partit Int_Un_distrib2 finite_Un
+  thus ?thesis
+    using fin_A set_partit Int_Un_distrib2 finite_Un
           card_Un_disjoint sup_bot.right_neutral
     by metis
 qed
 
 lemma defer_subset:
-  assumes "well_formed A result"
-  shows "defer_r result \<subseteq> A"
+  fixes
+    A :: "'a set" and
+    r :: "'a Result"
+  assumes "well_formed A r"
+  shows "defer_r r \<subseteq> A"
 proof (safe)
-  fix x :: "'a"
-  assume def_x: "x \<in> defer_r result"
+  fix a :: "'a"
+  assume def_a: "a \<in> defer_r r"
   obtain
     alts :: "'a Result \<Rightarrow> 'a set \<Rightarrow> 'a set" and
     res :: "'a Result \<Rightarrow> 'a set \<Rightarrow> 'a Result" where
-    wf: "A = alts result A \<and> result = res result A \<and> disjoint3 (res result A) \<and>
-            set_equals_partition (alts result A) (res result A)"
+    wf: "A = alts r A \<and> r = res r A \<and> disjoint3 (res r A) \<and>
+            set_equals_partition (alts r A) (res r A)"
     using assms
     by simp
-  hence
-    "\<forall> p A. \<exists> elec rej def.
-      set_equals_partition (A::'a set) p \<longrightarrow> (elec, rej, def) = p \<and> elec \<union> rej \<union> def = A"
+  hence "\<forall> p. \<exists> E R D. set_equals_partition A p \<longrightarrow> (E, R, D) = p \<and> E \<union> R \<union> D = A"
     by simp
-  thus "x \<in> A"
-    using UnCI def_x wf snd_conv
+  thus "a \<in> A"
+    using UnCI def_a wf snd_conv
     by metis
 qed
 
 lemma elect_subset:
-  assumes "well_formed A result"
-  shows "elect_r result \<subseteq> A"
+  fixes
+    A :: "'a set" and
+    r :: "'a Result"
+  assumes "well_formed A r"
+  shows "elect_r r \<subseteq> A"
 proof (safe)
   fix x :: "'a"
-  assume elec_res: "x \<in> elect_r result"
+  assume elec_res: "x \<in> elect_r r"
   obtain
     alts :: "'a Result \<Rightarrow> 'a set \<Rightarrow> 'a set" and
     res :: "'a Result \<Rightarrow> 'a set \<Rightarrow> 'a Result" where
-    wf: "A = alts result A \<and> result = res result A \<and> disjoint3 (res result A) \<and>
-            set_equals_partition (alts result A) (res result A)"
+    wf: "A = alts r A \<and> r = res r A \<and> disjoint3 (res r A) \<and>
+            set_equals_partition (alts r A) (res r A)"
     using assms
     by simp
-  hence
-    "\<forall> p A. \<exists> elec rej def.
-      set_equals_partition (A::'a set) p \<longrightarrow> (elec, rej, def) = p \<and> elec \<union> rej \<union> def = A"
+  hence "\<forall> p. \<exists> E R D. set_equals_partition A p \<longrightarrow> (E, R, D) = p \<and> E \<union> R \<union> D = A"
     by simp
   thus "x \<in> A"
     using UnCI elec_res wf assms fst_conv
@@ -181,21 +189,22 @@ proof (safe)
 qed
 
 lemma reject_subset:
-  assumes "well_formed A result"
-  shows "reject_r result \<subseteq> A"
+  fixes
+    A :: "'a set" and
+    r :: "'a Result"
+  assumes "well_formed A r"
+  shows "reject_r r \<subseteq> A"
 proof (safe)
   fix a :: "'a"
-  assume rej_a: "a \<in> reject_r result"
+  assume rej_a: "a \<in> reject_r r"
   obtain
     alts :: "'a Result \<Rightarrow> 'a set \<Rightarrow> 'a set" and
     res :: "'a Result \<Rightarrow> 'a set \<Rightarrow> 'a Result" where
-    wf: "A = alts result A \<and> result = res result A \<and> disjoint3 (res result A) \<and>
-            set_equals_partition (alts result A) (res result A)"
+    wf: "A = alts r A \<and> r = res r A \<and> disjoint3 (res r A) \<and>
+            set_equals_partition (alts r A) (res r A)"
     using assms
     by simp
-  hence
-    "\<forall> p A. \<exists> elec rej def.
-      set_equals_partition (A::'a set) p \<longrightarrow> (elec, rej, def) = p \<and> elec \<union> rej \<union> def = A"
+  hence "\<forall> p. \<exists> E R D. set_equals_partition A p \<longrightarrow> (E, R, D) = p \<and> E \<union> R \<union> D = A"
     by simp
   thus "a \<in> A"
     using UnCI assms rej_a wf fst_conv snd_conv disjoint3.cases

--- a/theories/Compositional_Structures/Basic_Modules/Condorcet_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Condorcet_Module.thy
@@ -28,6 +28,13 @@ fun condorcet_score :: "'a Evaluation_Function" where
 fun condorcet :: "'a Electoral_Module" where
   "condorcet A p = (max_eliminator condorcet_score) A p"
 
+subsection \<open>Soundness\<close>
+
+theorem condorcet_sound: "electoral_module condorcet"
+  unfolding condorcet.simps
+  using max_elim_sound
+  by metis
+
 subsection \<open>Property\<close>
 
 (* Condorcet score is Condorcet rating. *)

--- a/theories/Compositional_Structures/Basic_Modules/Condorcet_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Condorcet_Module.thy
@@ -75,9 +75,9 @@ next
   fix
     A :: "'a set" and
     p :: "'a Profile" and
-    w :: "'a"
+    a :: "'a"
   assume
-    cwin_w: "condorcet_winner A p w" and
+    cwin_w: "condorcet_winner A p a" and
     finA: "finite A"
   have max_cscore_dcc:
     "defer_condorcet_consistency (max_eliminator condorcet_score)"
@@ -85,9 +85,9 @@ next
     by (simp add: condorcet_score_is_condorcet_rating)
   have
     "max_eliminator condorcet_score A p =
-  ({},
-  A - defer (max_eliminator condorcet_score) A p,
-  {a \<in> A. condorcet_winner A p a})"
+      ({},
+      A - defer (max_eliminator condorcet_score) A p,
+      {b \<in> A. condorcet_winner A p b})"
     using cwin_w finA max_cscore_dcc
     unfolding defer_condorcet_consistency_def
     by (metis (no_types))

--- a/theories/Compositional_Structures/Basic_Modules/Copeland_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Copeland_Module.thy
@@ -28,6 +28,13 @@ fun copeland_score :: "'a Evaluation_Function" where
 fun copeland :: "'a Electoral_Module" where
   "copeland A p = max_eliminator copeland_score A p"
 
+subsection \<open>Soundness\<close>
+
+theorem copeland_sound: "electoral_module copeland"
+  unfolding copeland.simps
+  using max_elim_sound
+  by metis
+
 subsection \<open>Lemmata\<close>
 
 text \<open>

--- a/theories/Compositional_Structures/Basic_Modules/Copeland_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Copeland_Module.thy
@@ -35,25 +35,29 @@ theorem copeland_sound: "electoral_module copeland"
   using max_elim_sound
   by metis
 
-subsection \<open>Lemmata\<close>
+subsection \<open>Lemmas\<close>
 
 text \<open>
   For a Condorcet winner w, we have: "card {y in A . wins x p y} = |A| - 1".
 \<close>
 
 lemma cond_winner_imp_win_count:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    w :: "'a"
   assumes "condorcet_winner A p w"
-  shows "card {y \<in> A . wins w p y} = card A - 1"
+  shows "card {a \<in> A. wins w p a} = card A - 1"
 proof -
   from assms
-  have 0: "\<forall> x \<in> A - {w} . wins w p x"
+  have 0: "\<forall> a \<in> A - {w}. wins w p a"
     by simp
-  have 1: "\<forall> M . {x \<in> M . True} = M"
+  have 1: "\<forall> M. {x \<in> M. True} = M"
     by blast
   from 0 1
-  have "{x \<in> A - {w} . wins w p x} = A - {w}"
+  have "{a \<in> A - {w}. wins w p a} = A - {w}"
     by blast
-  hence 10: "card {x \<in> A - {w} . wins w p x} = card (A - {w})"
+  hence 10: "card {a \<in> A - {w}. wins w p a} = card (A - {w})"
     by simp
   from assms
   have 11: "w \<in> A"
@@ -61,42 +65,42 @@ proof -
   hence "card (A - {w}) = card A - 1"
     using card_Diff_singleton assms
     by metis
-  hence amount1:
-    "card {x \<in> A - {w} . wins w p x} = card (A) - 1"
+  hence winner_amount_one:
+    "card {a \<in> A - {w}. wins w p a} = card (A) - 1"
     using "10"
     by linarith
-  have 2: "\<forall> x \<in> {w} . \<not> wins x p x"
+  have 2: "\<forall> a \<in> {w}. \<not> wins a p a"
     by (simp add: wins_irreflex)
-  have 3: "\<forall> M . {x \<in> M . False} = {}"
+  have 3: "\<forall> M. {x \<in> M . False} = {}"
     by blast
   from 2 3
-  have "{x \<in> {w} . wins w p x} = {}"
+  have "{a \<in> {w}. wins w p a} = {}"
     by blast
-  hence amount2: "card {x \<in> {w} . wins w p x} = 0"
+  hence winner_amount_zero: "card {a \<in> {w}. wins w p a} = 0"
     by simp
   have disjunct:
-    "{x \<in> A - {w} . wins w p x} \<inter> {x \<in> {w} . wins w p x} = {}"
+    "{a \<in> A - {w}. wins w p a} \<inter> {a \<in> {w}. wins w p a} = {}"
     by blast
   have union:
-    "{x \<in> A - {w} . wins w p x} \<union> {x \<in> {w} . wins w p x} =
-        {x \<in> A . wins w p x}"
+    "{a \<in> A - {w}. wins w p a} \<union> {x \<in> {w}. wins w p x} =
+        {a \<in> A. wins w p a}"
     using 2
     by blast
-  have finiteness1: "finite {x \<in> A - {w} . wins w p x}"
+  have finite_defeated: "finite {a \<in> A - {w}. wins w p a}"
     using assms
     by simp
-  have finiteness2: "finite {x \<in> {w} . wins w p x}"
+  have finitene_winners: "finite {a \<in> {w}. wins w p a}"
     by simp
-  from finiteness1 finiteness2 disjunct card_Un_disjoint
+  from finite_defeated finitene_winners disjunct card_Un_disjoint
   have
-    "card ({x \<in> A - {w} . wins w p x} \<union> {x \<in> {w} . wins w p x}) =
-        card {x \<in> A - {w} . wins w p x} + card {x \<in> {w} . wins w p x}"
+    "card ({a \<in> A - {w}. wins w p a} \<union> {a \<in> {w}. wins w p a}) =
+        card {a \<in> A - {w}. wins w p a} + card {a \<in> {w}. wins w p a}"
     by blast
   with union
-  have "card {x \<in> A . wins w p x} =
-          card {x \<in> A - {w} . wins w p x} + card {x \<in> {w} . wins w p x}"
+  have "card {a \<in> A. wins w p a} =
+          card {a \<in> A - {w}. wins w p a} + card {a \<in> {w}. wins w p a}"
     by simp
-  with amount1 amount2
+  with winner_amount_one winner_amount_zero
   show ?thesis
     by linarith
 qed
@@ -106,8 +110,12 @@ text \<open>
 \<close>
 
 lemma cond_winner_imp_loss_count:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    w :: "'a"
   assumes winner: "condorcet_winner A p w"
-  shows "card {y \<in> A . wins y p w} = 0"
+  shows "card {a \<in> A. wins a p w} = 0"
   using Collect_empty_eq card_eq_0_iff insert_Diff insert_iff
         wins_antisym winner
   unfolding condorcet_winner.simps
@@ -118,6 +126,10 @@ text \<open>
 \<close>
 
 lemma cond_winner_imp_copeland_score:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    w :: "'a"
   assumes winner: "condorcet_winner A p w"
   shows "copeland_score w A p = card A - 1"
 proof (unfold copeland_score.simps)
@@ -130,7 +142,7 @@ proof (unfold copeland_score.simps)
   have "card A - 1 - 0 = card A - 1"
     by simp
   thus
-    "card {y \<in> A. wins w p y} - card {y \<in> A. wins y p w} =
+    "card {a \<in> A. wins w p a} - card {a \<in> A. wins a p w} =
       card A - 1"
     using card_zero card_A_sub_one
     by simp
@@ -142,11 +154,16 @@ text \<open>
 \<close>
 
 lemma non_cond_winner_imp_win_count:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    w :: "'a" and
+    l :: "'a"
   assumes
     winner: "condorcet_winner A p w" and
     loser: "l \<noteq> w" and
     l_in_A: "l \<in> A"
-  shows "card {y \<in> A . wins l p y} \<le> card A - 2"
+  shows "card {a \<in> A . wins l p a} \<le> card A - 2"
 proof -
   from winner loser l_in_A
   have "wins w p l"

--- a/theories/Compositional_Structures/Basic_Modules/Drop_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Drop_Module.thy
@@ -31,7 +31,11 @@ fun drop_module :: "nat \<Rightarrow> 'a Preference_Relation \<Rightarrow> 'a El
 
 subsection \<open>Soundness\<close>
 
-theorem drop_mod_sound[simp]: "electoral_module (drop_module n r)"
+theorem drop_mod_sound[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
+  shows "electoral_module (drop_module n r)"
 proof (intro electoral_modI)
   fix
     A :: "'a set" and
@@ -68,6 +72,9 @@ text \<open>
 \<close>
 
 theorem drop_mod_non_electing[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
   assumes "linear_order r"
   shows "non_electing (drop_module n r)"
   unfolding non_electing_def
@@ -81,6 +88,9 @@ text \<open>
 \<close>
 
 theorem drop_mod_def_lift_inv[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
   assumes "linear_order r"
   shows "defer_lift_invariance (drop_module n r)"
   unfolding defer_lift_invariance_def

--- a/theories/Compositional_Structures/Basic_Modules/Minimax_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Minimax_Module.thy
@@ -26,6 +26,13 @@ fun minimax_score :: "'a Evaluation_Function" where
 fun minimax :: "'a Electoral_Module" where
   "minimax A p = max_eliminator minimax_score A p"
 
+subsection \<open>Soundness\<close>
+
+theorem minimax_sound: "electoral_module minimax"
+  unfolding minimax.simps
+  using max_elim_sound
+  by metis
+
 subsection \<open>Lemma\<close>
 
 lemma non_cond_winner_minimax_score:

--- a/theories/Compositional_Structures/Basic_Modules/Minimax_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Minimax_Module.thy
@@ -36,6 +36,11 @@ theorem minimax_sound: "electoral_module minimax"
 subsection \<open>Lemma\<close>
 
 lemma non_cond_winner_minimax_score:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    w :: "'a" and
+    l :: "'a"
   assumes
     prof: "profile A p" and
     winner: "condorcet_winner A p w" and

--- a/theories/Compositional_Structures/Basic_Modules/Pass_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Pass_Module.thy
@@ -30,6 +30,9 @@ fun pass_module :: "nat \<Rightarrow> 'a Preference_Relation \<Rightarrow> 'a El
 subsection \<open>Soundness\<close>
 
 theorem pass_mod_sound[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
   assumes "linear_order r"
   shows "electoral_module (pass_module n r)"
 proof (intro electoral_modI)
@@ -70,6 +73,9 @@ text \<open>
 \<close>
 
 theorem pass_mod_non_blocking[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
   assumes
     order: "linear_order r" and
     g0_n:  "n > 0"
@@ -82,27 +88,27 @@ next
   fix
     A :: "'a set" and
     p :: "'a Profile" and
-    x :: "'a"
+    a :: "'a"
   assume
     fin_A: "finite A" and
     prof_A: "profile A p" and
     card_A:
-    "{a \<in> A. n <
+    "{b \<in> A. n <
       card (above
-        {(a, b). (a, b) \<in> r \<and>
-          a \<in> A \<and> b \<in> A} a)} = A" and
-    x_in_A: "x \<in> A"
+        {(b, c). (b, c) \<in> r \<and>
+          b \<in> A \<and> c \<in> A} b)} = A" and
+    a_in_A: "a \<in> A"
   have lin_ord_A:
     "linear_order_on A (limit A r)"
     using limit_presv_lin_ord order top_greatest
     by metis
   have
-    "\<exists> a \<in> A. above (limit A r) a = {a} \<and>
-      (\<forall> x \<in> A. above (limit A r) x = {x} \<longrightarrow> x = a)"
-    using above_one fin_A lin_ord_A x_in_A
+    "\<exists> b \<in> A. above (limit A r) b = {b} \<and>
+      (\<forall> c \<in> A. above (limit A r) c = {c} \<longrightarrow> c = b)"
+    using above_one fin_A lin_ord_A a_in_A
     by blast
   hence not_all:
-    "{a \<in> A. card(above (limit A r) a) > n} \<noteq> A"
+    "{b \<in> A. card(above (limit A r) b) > n} \<noteq> A"
     using Suc_leI assms(2) is_singletonI
           is_singleton_altdef leD mem_Collect_eq
     unfolding One_nat_def
@@ -121,6 +127,9 @@ text \<open>
 \<close>
 
 theorem pass_mod_non_electing[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
   assumes "linear_order r"
   shows "non_electing (pass_module n r)"
   unfolding non_electing_def
@@ -135,6 +144,9 @@ text \<open>
 \<close>
 
 theorem pass_mod_dl_inv[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
   assumes "linear_order r"
   shows "defer_lift_invariance (pass_module n r)"
   unfolding defer_lift_invariance_def
@@ -142,6 +154,7 @@ theorem pass_mod_dl_inv[simp]:
   by simp
 
 theorem pass_zero_mod_def_zero[simp]:
+  fixes r :: "'a Preference_Relation"
   assumes "linear_order r"
   shows "defers 0 (pass_module 0 r)"
 proof (unfold defers_def, safe)
@@ -160,7 +173,7 @@ next
     "linear_order_on A (limit A r)"
     using assms limit_presv_lin_ord
     by blast
-  have f1: "connex A (limit A r)"
+  have limit_is_connex: "connex A (limit A r)"
     using lin_ord_imp_connex lin_ord_on_A
     by simp
   obtain select_alt :: "('a \<Rightarrow> bool) \<Rightarrow> 'a" where
@@ -176,7 +189,7 @@ next
           equals0D finite_A assms rev_finite_subset
     by (metis (no_types))
   hence "{a \<in> A. card (above (limit A r) a) \<le> 0} = {}"
-    using f1
+    using limit_is_connex
     by auto
   hence "card {a \<in> A. card (above (limit A r) a) \<le> 0} = 0"
     using card.empty
@@ -193,6 +206,7 @@ text \<open>
 \<close>
 
 theorem pass_one_mod_def_one[simp]:
+  fixes r :: "'a Preference_Relation"
   assumes "linear_order r"
   shows "defers 1 (pass_module 1 r)"
 proof (unfold defers_def, safe)
@@ -218,69 +232,65 @@ next
       by blast
     ultimately have winner_exists:
       "\<exists> a \<in> A. above (limit A r) a = {a} \<and>
-        (\<forall> x \<in> A. above (limit A r) x = {x} \<longrightarrow> x = a)"
+        (\<forall> b \<in> A. above (limit A r) b = {b} \<longrightarrow> b = a)"
       using finite_A
       by (simp add: above_one)
     then obtain w where w_unique_top:
       "above (limit A r) w = {w} \<and>
-        (\<forall> x \<in> A. above (limit A r) x = {x} \<longrightarrow> x = w)"
+        (\<forall> a \<in> A. above (limit A r) a = {a} \<longrightarrow> a = w)"
       using above_one
       by auto
     hence "{a \<in> A. card(above (limit A r) a) \<le> 1} = {w}"
     proof
       assume
         w_top: "above (limit A r) w = {w}" and
-        w_unique: "\<forall> x \<in> A. above (limit A r) x = {x} \<longrightarrow> x = w"
+        w_unique: "\<forall> a \<in> A. above (limit A r) a = {a} \<longrightarrow> a = w"
       have "card (above (limit A r) w) \<le> 1"
         using w_top
         by auto
       hence "{w} \<subseteq> {a \<in> A. card (above (limit A r) a) \<le> 1}"
         using winner_exists w_unique_top
         by blast
-      moreover have
-        "{a \<in> A. card(above (limit A r) a) \<le> 1} \<subseteq> {w}"
+      moreover have "{a \<in> A. card(above (limit A r) a) \<le> 1} \<subseteq> {w}"
       proof
-        fix x :: "'a"
-        assume x_in_winner_set: "x \<in> {a \<in> A. card (above (limit A r) a) \<le> 1}"
-        hence x_in_A: "x \<in> A"
+        fix a :: "'a"
+        assume a_in_winner_set: "a \<in> {b \<in> A. card (above (limit A r) b) \<le> 1}"
+        hence a_in_A: "a \<in> A"
           by auto
-        hence connex_limit:
-          "connex A (limit A r)"
+        hence connex_limit: "connex A (limit A r)"
           using lin_ord_imp_connex lin_ord_on_A
           by simp
-        hence "let q = limit A r in x \<preceq>\<^sub>q x"
+        hence "let q = limit A r in a \<preceq>\<^sub>q a"
           using connex_limit above_connex
-                pref_imp_in_above x_in_A
+                pref_imp_in_above a_in_A
           by metis
-        hence "(x,x) \<in> limit A r"
+        hence "(a, a) \<in> limit A r"
           by simp
-        hence x_above_x: "x \<in> above (limit A r) x"
+        hence a_above_a: "a \<in> above (limit A r) a"
           unfolding above_def
           by simp
-        have "above (limit A r) x \<subseteq> A"
+        have "above (limit A r) a \<subseteq> A"
           using above_presv_limit assms
           by fastforce
-        hence above_finite: "finite (above (limit A r) x)"
+        hence above_finite: "finite (above (limit A r) a)"
           using finite_A finite_subset
           by simp
-        have "card (above (limit A r) x) \<le> 1"
-          using x_in_winner_set
+        have "card (above (limit A r) a) \<le> 1"
+          using a_in_winner_set
           by simp
-        moreover have
-          "card (above (limit A r) x) \<ge> 1"
+        moreover have "card (above (limit A r) a) \<ge> 1"
           using One_nat_def Suc_leI above_finite card_eq_0_iff
-                equals0D neq0_conv x_above_x
+                equals0D neq0_conv a_above_a
           by metis
-        ultimately have
-          "card (above (limit A r) x) = 1"
+        ultimately have "card (above (limit A r) a) = 1"
           by simp
-        hence "{x} = above (limit A r) x"
-          using is_singletonE is_singleton_altdef singletonD x_above_x
+        hence "{a} = above (limit A r) a"
+          using is_singletonE is_singleton_altdef singletonD a_above_a
           by metis
-        hence "x = w"
+        hence "a = w"
           using w_unique
-          by (simp add: x_in_A)
-        thus "x \<in> {w}"
+          by (simp add: a_in_A)
+        thus "a \<in> {w}"
           by simp
       qed
       ultimately have
@@ -297,6 +307,7 @@ next
 qed
 
 theorem pass_two_mod_def_two:
+  fixes r :: "'a Preference_Relation"
   assumes "linear_order r"
   shows "defers 2 (pass_module 2 r)"
 proof (unfold defers_def, safe)
@@ -367,7 +378,7 @@ next
     by auto
   hence c_not_above_b: "\<forall> c \<in> A - {a, b}. c \<notin> above (limit A r) b"
     using b Diff_iff Diff_insert2 above_presv_limit insert_subset
-          assms limit_presv_above limit_presv_above2
+          assms limit_presv_above limit_presv_above_2
     by metis
   moreover have above_subset: "above (limit A r) b \<subseteq> A"
     using above_presv_limit assms
@@ -385,8 +396,8 @@ next
   hence b_in_defer: "b \<in> defer (pass_module 2 r) A p"
     using b_above_b above_subset
     by auto
-  from b_best have b_above:
-    "\<forall> c \<in> A - {a}. b \<in> above (limit A r) c"
+  from b_best
+  have b_above: "\<forall> c \<in> A - {a}. b \<in> above (limit A r) c"
     using mem_Collect_eq
     unfolding above_def
     by metis
@@ -404,8 +415,7 @@ next
           insert_commute numeral_3_eq_3
     unfolding One_nat_def
     by metis
-  ultimately have
-    "\<forall> c \<in> A - {a, b}. card (above (limit A r) c) \<ge> 3"
+  ultimately have "\<forall> c \<in> A - {a, b}. card (above (limit A r) c) \<ge> 3"
     using card_mono finA finite_subset above_presv_limit assms
     by metis
   hence "\<forall> c \<in> A - {a, b}. card (above (limit A r) c) > 2"
@@ -417,8 +427,8 @@ next
     by auto
   ultimately have "defer (pass_module 2 r) A p \<subseteq> {a, b}"
     by blast
-  with a_in_defer b_in_defer have
-    "defer (pass_module 2 r) A p = {a, b}"
+  with a_in_defer b_in_defer
+  have "defer (pass_module 2 r) A p = {a, b}"
     by fastforce
   thus "card (defer (pass_module 2 r) A p) = 2"
     using above_b_eq_ab card_above_b_eq_2

--- a/theories/Compositional_Structures/Drop_And_Pass_Compatibility.thy
+++ b/theories/Compositional_Structures/Drop_And_Pass_Compatibility.thy
@@ -22,6 +22,7 @@ text \<open>
 subsection \<open>Properties\<close>
 
 theorem drop_zero_mod_rej_zero[simp]:
+  fixes r :: "'a Preference_Relation"
   assumes "linear_order r"
   shows "rejects 0 (drop_module 0 r)"
 proof (unfold rejects_def, safe)
@@ -43,11 +44,11 @@ next
     using f1 limit_presv_connex subset_UNIV
     by metis
   have
-    "\<forall> A a. A \<noteq> {} \<or> (a::'a) \<notin> A"
+    "\<forall> B a. B \<noteq> {} \<or> (a::'a) \<notin> B"
     by simp
   hence
-    "\<forall> a A'.
-      \<not> connex A' (limit A r) \<or> a \<notin> A' \<or> a \<notin> A \<or>
+    "\<forall> a B.
+      \<not> connex B (limit A r) \<or> a \<notin> B \<or> a \<notin> A \<or>
         \<not> card (above (limit A r) a) \<le> 0"
     using above_connex above_presv_limit card_eq_0_iff
           finite_A finite_subset le_0_eq assms
@@ -68,6 +69,7 @@ text \<open>
 \<close>
 
 theorem drop_two_mod_rej_two[simp]:
+  fixes r :: "'a Preference_Relation"
   assumes "linear_order r"
   shows "rejects 2 (drop_module 2 r)"
 proof -
@@ -77,41 +79,26 @@ proof -
   obtain
     m :: "('a Electoral_Module) \<Rightarrow> nat \<Rightarrow> 'a set" and
     m' :: "('a Electoral_Module) \<Rightarrow> nat \<Rightarrow> 'a Profile" where
-      "\<forall> f n. (\<exists> A p. (n \<le> card A \<and> finite_profile A p) \<and>
-        card (reject f A p) \<noteq> n) =
-          ((n \<le> card (m f n) \<and>
-            finite_profile (m f n) (m' f n)) \<and>
+      "\<forall> f n. (\<exists> A p. n \<le> card A \<and> finite_profile A p \<and> card (reject f A p) \<noteq> n) =
+          (n \<le> card (m f n) \<and> finite_profile (m f n) (m' f n) \<and>
             card (reject f (m f n) (m' f n)) \<noteq> n)"
     by moura
-  hence
-    "\<forall> n f. (\<not> rejects n f \<or> electoral_module f \<and>
-      (\<forall> A rs. (\<not> n \<le> card A \<or> infinite A \<or> \<not> profile A rs) \<or>
-          card (reject f A rs) = n)) \<and>
-        (rejects n f \<or> \<not> electoral_module f \<or> (n \<le> card (m f n) \<and>
-          finite_profile (m f n) (m' f n)) \<and>
-            card (reject f (m f n) (m' f n)) \<noteq> n)"
+  hence rejected_card:
+    "\<forall> f n.
+      (\<not> rejects n f \<and> electoral_module f \<longrightarrow>
+        n \<le> card (m f n) \<and> finite_profile (m f n) (m' f n) \<and>
+          card (reject f (m f n) (m' f n)) \<noteq> n)"
     unfolding rejects_def
     by blast
-  hence f1:
-    "\<forall> n f. (\<not> rejects n f \<or> electoral_module f \<and>
-      (\<forall> A rs. \<not> n \<le> card A \<or> infinite A \<or> \<not> profile A rs \<or>
-        card (reject f A rs) = n)) \<and>
-          (rejects n f \<or> \<not> electoral_module f \<or> n \<le> card (m f n) \<and>
-            finite (m f n) \<and> profile (m f n) (m' f n) \<and>
-            card (reject f (m f n) (m' f n)) \<noteq> n)"
-    by presburger
   have
-    "\<not> 2 \<le> card (m (drop_module 2 r) 2) \<or>
-      infinite (m (drop_module 2 r) 2) \<or>
-        \<not> profile (m (drop_module 2 r) 2) (m' (drop_module 2 r) 2) \<or>
-        card (reject (drop_module 2 r) (m (drop_module 2 r) 2)
-        (m' (drop_module 2 r) 2)) = 2"
-    using rej_drop_eq_def_pass assms
-          pass_two_mod_def_two
+    "2 \<le> card (m (drop_module 2 r) 2) \<and> finite (m (drop_module 2 r) 2) \<and>
+      profile (m (drop_module 2 r) 2) (m' (drop_module 2 r) 2) \<longrightarrow>
+        card (reject (drop_module 2 r) (m (drop_module 2 r) 2) (m' (drop_module 2 r) 2)) = 2"
+    using rej_drop_eq_def_pass assms pass_two_mod_def_two
     unfolding defers_def
     by (metis (no_types))
   thus ?thesis
-    using f1 drop_mod_sound assms
+    using rejected_card drop_mod_sound assms
     by blast
 qed
 
@@ -120,6 +107,9 @@ text \<open>
 \<close>
 
 theorem drop_pass_disj_compat[simp]:
+  fixes
+    r :: "'a Preference_Relation" and
+    n :: nat
   assumes "linear_order r"
   shows "disjoint_compatibility (drop_module n r) (pass_module n r)"
 proof (unfold disjoint_compatibility_def, safe)
@@ -131,55 +121,54 @@ next
     using assms
     by simp
 next
-  fix S :: "'a set"
-  assume fin: "finite S"
+  fix A :: "'a set"
+  assume fin: "finite A"
   obtain p :: "'a Profile" where
-    "finite_profile S p"
+    "finite_profile A p"
     using empty_iff empty_set fin profile_set
     by metis
   show
-    "\<exists> A \<subseteq> S.
-      (\<forall> a \<in> A. indep_of_alt (drop_module n r) S a \<and>
-        (\<forall> p. finite_profile S p \<longrightarrow>
-          a \<in> reject (drop_module n r) S p)) \<and>
-      (\<forall> a \<in> S - A. indep_of_alt (pass_module n r) S a \<and>
-        (\<forall> p. finite_profile S p \<longrightarrow>
-          a \<in> reject (pass_module n r) S p))"
+    "\<exists> B \<subseteq> A.
+      (\<forall> a \<in> B. indep_of_alt (drop_module n r) A a \<and>
+        (\<forall> p. finite_profile A p \<longrightarrow>
+          a \<in> reject (drop_module n r) A p)) \<and>
+      (\<forall> a \<in> A - B. indep_of_alt (pass_module n r) A a \<and>
+        (\<forall> p. finite_profile A p \<longrightarrow>
+          a \<in> reject (pass_module n r) A p))"
   proof
     have same_A:
-      "\<forall> p q. (finite_profile S p \<and> finite_profile S q) \<longrightarrow>
-        reject (drop_module n r) S p =
-          reject (drop_module n r) S q"
+      "\<forall> p q. (finite_profile A p \<and> finite_profile A q) \<longrightarrow>
+        reject (drop_module n r) A p =
+          reject (drop_module n r) A q"
       by auto
-    let ?A = "reject (drop_module n r) S p"
-    have "?A \<subseteq> S"
+    let ?A = "reject (drop_module n r) A p"
+    have "?A \<subseteq> A"
       by auto
-    moreover have
-      "(\<forall> a \<in> ?A. indep_of_alt (drop_module n r) S a)"
+    moreover have "\<forall> a \<in> ?A. indep_of_alt (drop_module n r) A a"
       using assms
       unfolding indep_of_alt_def
       by simp
     moreover have
-      "\<forall> a \<in> ?A. \<forall> p. finite_profile S p \<longrightarrow>
-        a \<in> reject (drop_module n r) S p"
+      "\<forall> a \<in> ?A. \<forall> p. finite_profile A p \<longrightarrow>
+        a \<in> reject (drop_module n r) A p"
       by auto
     moreover have
-      "(\<forall> a \<in> S - ?A. indep_of_alt (pass_module n r) S a)"
+      "(\<forall> a \<in> A - ?A. indep_of_alt (pass_module n r) A a)"
       using assms
       unfolding indep_of_alt_def
       by simp
     moreover have
-      "\<forall> a \<in> S - ?A. \<forall> p. finite_profile S p \<longrightarrow>
-        a \<in> reject (pass_module n r) S p"
+      "\<forall> a \<in> A - ?A. \<forall> p. finite_profile A p \<longrightarrow>
+        a \<in> reject (pass_module n r) A p"
       by auto
     ultimately show
-      "?A \<subseteq> S \<and>
-        (\<forall> a \<in> ?A. indep_of_alt (drop_module n r) S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow>
-            a \<in> reject (drop_module n r) S p)) \<and>
-        (\<forall> a \<in> S - ?A. indep_of_alt (pass_module n r) S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow>
-            a \<in> reject (pass_module n r) S p))"
+      "?A \<subseteq> A \<and>
+        (\<forall> a \<in> ?A. indep_of_alt (drop_module n r) A a \<and>
+          (\<forall> p. finite_profile A p \<longrightarrow>
+            a \<in> reject (drop_module n r) A p)) \<and>
+        (\<forall> a \<in> A - ?A. indep_of_alt (pass_module n r) A a \<and>
+          (\<forall> p. finite_profile A p \<longrightarrow>
+            a \<in> reject (pass_module n r) A p))"
       by simp
   qed
 qed

--- a/theories/Compositional_Structures/Elect_Composition.thy
+++ b/theories/Compositional_Structures/Elect_Composition.thy
@@ -28,6 +28,7 @@ fun elector :: "'a Electoral_Module \<Rightarrow> 'a Electoral_Module" where
 subsection \<open>Soundness\<close>
 
 theorem elector_sound[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes "electoral_module m"
   shows "electoral_module (elector m)"
   using assms
@@ -36,6 +37,7 @@ theorem elector_sound[simp]:
 subsection \<open>Electing\<close>
 
 theorem elector_electing[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes
     module_m: "electoral_module m" and
     non_block_m: "non_blocking m"
@@ -99,6 +101,7 @@ text \<open>
 \<close>
 
 lemma dcc_imp_cc_elector:
+  fixes m :: "'a Electoral_Module"
   assumes "defer_condorcet_consistency m"
   shows "condorcet_consistency (elector m)"
 proof (unfold defer_condorcet_consistency_def
@@ -200,7 +203,7 @@ next
   thus "xa = x"
     using 1 2 condorcet_winner.simps assms empty_iff xa_in_A
           defer_condorcet_consistency_def 3 DiffI
-          cond_winner_unique3 insert_iff prod.sel(2)
+          cond_winner_unique_3 insert_iff prod.sel(2)
     by (metis (no_types, lifting))
 next
   fix
@@ -229,7 +232,7 @@ next
   ultimately show "x \<in> elect m A p"
     using 1 condorcet_winner.simps assms
           defer_condorcet_consistency_def
-          cond_winner_unique3 insert_iff eq_snd_iff
+          cond_winner_unique_3 insert_iff eq_snd_iff
     by (metis (no_types, lifting))
 next
   fix

--- a/theories/Compositional_Structures/Loop_Composition.thy
+++ b/theories/Compositional_Structures/Loop_Composition.thy
@@ -23,6 +23,12 @@ text \<open>
 subsection \<open>Definition\<close>
 
 lemma loop_termination_helper:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     not_term: "\<not>t (acc A p)" and
     subset: "defer (acc \<triangleright> m) A p \<subset> defer acc A p" and
@@ -44,7 +50,7 @@ function loop_comp_helper ::
   "t (acc A p) \<or> \<not>((defer (acc \<triangleright> m) A p) \<subset> (defer acc A p)) \<or>
     infinite (defer acc A p) \<Longrightarrow>
       loop_comp_helper acc m t A p = acc A p" |
-  "\<not>(t (acc A p) \<or> \<not>((defer (acc \<triangleright> m) A p) \<subset> (defer acc A p)) \<or>
+  "\<not> (t (acc A p) \<or> \<not>((defer (acc \<triangleright> m) A p) \<subset> (defer acc A p)) \<or>
     infinite (defer acc A p)) \<Longrightarrow>
       loop_comp_helper acc m t A p = loop_comp_helper (acc \<triangleright> m) m t A p"
 proof -
@@ -52,28 +58,26 @@ proof -
     P :: bool and
     x :: "('a Electoral_Module) \<times> ('a Electoral_Module) \<times>
           ('a Termination_Condition) \<times> 'a set \<times> 'a Profile"
-  assume
-    a1: "\<And> t acc A p m.
-          \<lbrakk>t (acc A p) \<or> \<not> defer (acc \<triangleright> m) A p \<subset> defer acc A p \<or>
-              infinite (defer acc A p);
-            x = (acc, m, t, A, p)\<rbrakk> \<Longrightarrow> P" and
-    a2: "\<And> t acc A p m.
-          \<lbrakk>\<not> (t (acc A p) \<or> \<not> defer (acc \<triangleright> m) A p \<subset> defer acc A p \<or>
-              infinite (defer acc A p));
-            x = (acc, m, t, A, p)\<rbrakk> \<Longrightarrow> P"
-  have "\<exists> f A p p2 g. (g, f, p, A, p2) = x"
+  have x_exists: "\<exists> f A p p2 g. (g, f, p, A, p2) = x"
     using prod_cases5
     by metis
+  assume
+    a1: "\<And> t acc A p m.
+          t (acc A p) \<or> \<not> defer (acc \<triangleright> m) A p \<subset> defer acc A p \<or> \<not> finite (defer acc A p) \<Longrightarrow>
+            x = (acc, m, t, A, p) \<Longrightarrow> P" and
+    a2: "\<And> t acc A p m.
+          \<not> (t (acc A p) \<or> \<not> defer (acc \<triangleright> m) A p \<subset> defer acc A p \<or> \<not> finite (defer acc A p)) \<Longrightarrow>
+            x = (acc, m, t, A, p) \<Longrightarrow> P"
   thus P
-    using a2 a1
+    using x_exists
     by (metis (no_types))
 next
   show
     "\<And> t acc A p m ta acca Aa pa ma.
        t (acc A p) \<or> \<not> defer (acc \<triangleright> m) A p \<subset> defer acc A p \<or>
-        infinite (defer acc A p) \<Longrightarrow>
+        \<not> finite (defer acc A p) \<Longrightarrow>
           ta (acca Aa pa) \<or> \<not> defer (acca \<triangleright> ma) Aa pa \<subset> defer acca Aa pa \<or>
-          infinite (defer acca Aa pa) \<Longrightarrow>
+          \<not> finite (defer acca Aa pa) \<Longrightarrow>
            (acc, m, t, A, p) = (acca, ma, ta, Aa, pa) \<Longrightarrow>
               acc A p = acca Aa pa"
     by fastforce
@@ -126,7 +130,7 @@ termination
 proof -
   have func_term:
     "\<exists> r. wf r \<and>
-        (\<forall>p f (A::'a set) prof g.
+        (\<forall> p f (A::'a set) prof g.
           p (f A prof) \<or>
           \<not> defer (f \<triangleright> g) A prof \<subset> defer f A prof \<or>
           infinite (defer f A prof) \<or>
@@ -136,7 +140,7 @@ proof -
   hence
     "\<forall> r p.
       Ex ((\<lambda> ra. \<forall> f (A::'a set) prof pa g.
-            \<exists> prof2 pb p_rel pc pd h (B::'a set) prof3 i pe.
+            \<exists> prof' pb p_rel pc pd h (B::'a set) prof'' i pe.
         \<not> wf r \<or>
           loop_comp_helper_dom
             (p::('a Electoral_Module) \<times> (_ Electoral_Module) \<times>
@@ -144,7 +148,7 @@ proof -
           infinite (defer f A prof) \<or>
           pa (f A prof) \<and>
             wf
-              (prof2::((
+              (prof'::((
                 ('a Electoral_Module) \<times> ('a Electoral_Module) \<times>
                 ('a Termination_Condition) \<times> 'a set \<times> 'a Profile) \<times> _) set) \<and>
             \<not> loop_comp_helper_dom (pb::
@@ -158,10 +162,10 @@ proof -
             \<not> loop_comp_helper_dom
                 (pd::('a Electoral_Module) \<times> (_ Electoral_Module) \<times>
                   (_ Termination_Condition) \<times> _ set \<times> _ Profile) \<or>
-            finite (defer h B prof3) \<and>
-            defer (h \<triangleright> i) B prof3 \<subset> defer h B prof3 \<and>
-            \<not> pe (h B prof3) \<and>
-            ((h \<triangleright> i, i, pe, B, prof3), h, i, pe, B, prof3) \<notin> r)::
+            finite (defer h B prof'') \<and>
+            defer (h \<triangleright> i) B prof'' \<subset> defer h B prof'' \<and>
+            \<not> pe (h B prof'') \<and>
+            ((h \<triangleright> i, i, pe, B, prof''), h, i, pe, B, prof'') \<notin> r)::
           ((('a Electoral_Module) \<times> ('a Electoral_Module) \<times>
             ('a Termination_Condition) \<times> 'a set \<times> 'a Profile) \<times>
             ('a Electoral_Module) \<times> ('a Electoral_Module) \<times>
@@ -185,19 +189,23 @@ proof -
 qed
 
 lemma loop_comp_code_helper[code]:
-  "loop_comp_helper acc m t A p =
-    (if (t (acc A p) \<or> \<not>((defer (acc \<triangleright> m) A p) \<subset> (defer acc A p)) \<or>
-      infinite (defer acc A p))
-    then (acc A p) else (loop_comp_helper (acc \<triangleright> m) m t A p))"
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
+  shows
+    "loop_comp_helper acc m t A p =
+      (if (t (acc A p) \<or> \<not>((defer (acc \<triangleright> m) A p) \<subset> (defer acc A p)) \<or>
+        infinite (defer acc A p))
+      then (acc A p) else (loop_comp_helper (acc \<triangleright> m) m t A p))"
   by simp
 
 function loop_composition ::
-    "'a Electoral_Module \<Rightarrow> 'a Termination_Condition \<Rightarrow>
-        'a Electoral_Module" where
-  "t ({}, {}, A) \<Longrightarrow>
-    loop_composition m t A p = defer_module A p" |
-  "\<not>(t ({}, {}, A)) \<Longrightarrow>
-    loop_composition m t A p = (loop_comp_helper m m t) A p"
+    "'a Electoral_Module \<Rightarrow> 'a Termination_Condition \<Rightarrow> 'a Electoral_Module" where
+  "t ({}, {}, A) \<Longrightarrow> loop_composition m t A p = defer_module A p" |
+  "\<not>(t ({}, {}, A)) \<Longrightarrow> loop_composition m t A p = (loop_comp_helper m m t) A p"
   by (fastforce, simp_all)
 termination
   using "termination" wf_empty
@@ -209,12 +217,24 @@ abbreviation loop ::
   "m \<circlearrowleft>\<^sub>t \<equiv> loop_composition m t"
 
 lemma loop_comp_code[code]:
-  "loop_composition m t A p =
-    (if (t ({},{},A))
-    then (defer_module A p) else (loop_comp_helper m m t) A p)"
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    A :: "'a set" and
+    p :: "'a Profile"
+  shows
+    "loop_composition m t A p =
+      (if (t ({},{},A)) then (defer_module A p) else (loop_comp_helper m m t) A p)"
   by simp
 
 lemma loop_comp_helper_imp_partit:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    n :: nat
   assumes
     module_m: "electoral_module m" and
     profile: "finite_profile A p"
@@ -251,14 +271,23 @@ qed
 subsection \<open>Soundness\<close>
 
 theorem loop_comp_sound:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition"
   assumes "electoral_module m"
   shows "electoral_module (m \<circlearrowleft>\<^sub>t)"
-  using def_mod_sound loop_composition.simps(1) loop_composition.simps(2)
-        loop_comp_helper_imp_partit assms
+  using def_mod_sound loop_composition.simps(1, 2) loop_comp_helper_imp_partit assms
   unfolding electoral_module_def
   by metis
 
 lemma loop_comp_helper_imp_no_def_incr:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    n :: nat
   assumes
     module_m: "electoral_module m" and
     profile: "finite_profile A p"
@@ -290,9 +319,15 @@ proof (induct arbitrary: acc rule: less_induct)
     by (metis (no_types))
 qed
 
-subsection \<open>Lemmata\<close>
+subsection \<open>Lemmas\<close>
 
 lemma loop_comp_helper_def_lift_inv_helper:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     monotone_m: "defer_lift_invariance m" and
     f_prof: "finite_profile A p"
@@ -325,7 +360,7 @@ proof (induct n arbitrary: acc rule: less_induct)
     unfolding defer_lift_invariance_def
     by metis
   thus ?case
-  proof cases
+  proof (cases)
     assume card_unchanged: "card (defer (acc \<triangleright> m) A p) = card (defer acc A p)"
     with defer_card_comp defer_card_acc monotone_m
     have
@@ -372,8 +407,7 @@ proof (induct n arbitrary: acc rule: less_induct)
     qed
     moreover from card_unchanged
     have "(loop_comp_helper acc m t) A p = acc A p"
-      using loop_comp_helper.simps(1) order.strict_iff_order
-            psubset_card_mono
+      using loop_comp_helper.simps(1) order.strict_iff_order psubset_card_mono
       by metis
     ultimately have
       "(defer_lift_invariance (acc \<triangleright> m) \<and> defer_lift_invariance acc) \<longrightarrow>
@@ -404,7 +438,7 @@ proof (induct n arbitrary: acc rule: less_induct)
       unfolding defer_lift_invariance_def
       by (metis (no_types, lifting))
     thus ?thesis
-    proof cases
+    proof (cases)
       assume t_not_satisfied_for_p: "\<not> t (acc A p)"
       hence t_not_satisfied_for_q:
         "defer_lift_invariance (acc) \<longrightarrow>
@@ -555,6 +589,12 @@ proof (induct n arbitrary: acc rule: less_induct)
 qed
 
 lemma loop_comp_helper_def_lift_inv:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     monotone_m: "defer_lift_invariance m" and
     monotone_acc: "defer_lift_invariance acc" and
@@ -566,7 +606,15 @@ lemma loop_comp_helper_def_lift_inv:
         monotone_m monotone_acc profile
   by blast
 
-lemma loop_comp_helper_def_lift_inv2:
+lemma loop_comp_helper_def_lift_inv_2:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile" and
+    a :: "'a"
   assumes
     monotone_m: "defer_lift_invariance m" and
     monotone_acc: "defer_lift_invariance acc" and
@@ -580,6 +628,11 @@ lemma loop_comp_helper_def_lift_inv2:
   by blast
 
 lemma lifted_imp_fin_prof:
+  fixes
+    A :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile" and
+    a :: "'a"
   assumes "lifted A p q a"
   shows "finite_profile A p"
   using assms
@@ -587,6 +640,10 @@ lemma lifted_imp_fin_prof:
   by simp
 
 lemma loop_comp_helper_presv_def_lift_inv:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module"
   assumes
     monotone_m: "defer_lift_invariance m" and
     monotone_acc: "defer_lift_invariance acc"
@@ -612,6 +669,13 @@ next
 qed
 
 lemma loop_comp_presv_non_electing_helper:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    n :: nat
   assumes
     non_electing_m: "non_electing m" and
     non_electing_acc: "non_electing acc" and
@@ -678,10 +742,18 @@ proof (induct n arbitrary: acc rule: less_induct)
 qed
 
 lemma loop_comp_helper_iter_elim_def_n_helper:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    n :: nat and
+    x :: nat
   assumes
     non_electing_m: "non_electing m" and
     single_elimination: "eliminates 1 m" and
-    terminate_if_n_left: "\<forall> r. ((t r) \<longleftrightarrow> (card (defer_r r) = x))" and
+    terminate_if_n_left: "\<forall> r. ((t r) = (card (defer_r r) = x))" and
     x_greater_zero: "x > 0" and
     f_prof: "finite_profile A p" and
     n_acc_defer_card: "n = card (defer acc A p)" and
@@ -703,7 +775,7 @@ proof (induct n arbitrary: acc rule: less_induct)
     unfolding non_electing_def
     by metis
   thus ?case
-  proof cases
+  proof (cases)
     assume term_satisfied: "t (acc A p)"
     have "card (defer_r (loop_comp_helper acc m t A p)) = x"
       using loop_comp_helper.simps(1) term_satisfied terminate_if_n_left
@@ -724,15 +796,16 @@ proof (induct n arbitrary: acc rule: less_induct)
       unfolding non_electing_def
       by metis
     thus ?case
-    proof cases
+    proof (cases)
       assume card_too_small:
         "card (defer acc A p) < x"
       thus ?thesis
-        using not_le card_too_small less.prems(1) less.prems(4) not_le
+        using not_le card_too_small less.prems(1, 4) not_le
         by (metis (no_types))
     next
       assume old_card_at_least_x: "\<not>(card (defer acc A p) < x)"
-      obtain i where i_is_new_card: "i = card (defer (acc \<triangleright> m) A p)"
+      obtain i where
+        i_is_new_card: "i = card (defer (acc \<triangleright> m) A p)"
         by simp
       with card_not_eq_x
       have card_too_big:
@@ -757,7 +830,7 @@ proof (induct n arbitrary: acc rule: less_induct)
               (limit_profile (defer acc A p) p)) =
                 card (defer acc A p) - 1"
         using non_electing_m single_elimination
-              single_elim_decr_def_card2 enough_leftover
+              single_elim_decr_def_card_2 enough_leftover
         by metis
       hence "electoral_module acc \<longrightarrow> i = card (defer acc A p) - 1"
         using snd_conv i_is_new_card
@@ -783,7 +856,7 @@ proof (induct n arbitrary: acc rule: less_induct)
         using nat_less_le new_card_still_big_enough
         by metis
       thus ?thesis
-      proof cases
+      proof (cases)
         assume new_card_greater_x: "electoral_module acc \<longrightarrow> i > x"
         hence "electoral_module acc \<longrightarrow> 1 < card (defer (acc \<triangleright> m) A p)"
           using x_greater_zero i_is_new_card
@@ -814,7 +887,8 @@ proof (induct n arbitrary: acc rule: less_induct)
                   card (defer (loop_comp_helper (acc \<triangleright> m) m t) A p) = x"
           using less.hyps i_is_new_card new_card_greater_x
           by metis
-        have f1: "loop_comp_helper acc m t A p = loop_comp_helper (acc \<triangleright> m) m t A p"
+        have loop_comp_helper_seq:
+          "loop_comp_helper acc m t A p = loop_comp_helper (acc \<triangleright> m) m t A p"
           using enough_leftover f_prof less.prems(3) rec_step
           by metis
         have "electoral_module acc"
@@ -822,7 +896,7 @@ proof (induct n arbitrary: acc rule: less_induct)
           unfolding non_electing_def
           by simp
         thus ?thesis
-          using f1 card_x less.prems(3) less.prems(4)
+          using loop_comp_helper_seq card_x less.prems(3, 4)
           by presburger
       next
         assume i_not_gt_x: "\<not>(electoral_module acc \<longrightarrow> i > x)"
@@ -849,10 +923,17 @@ proof (induct n arbitrary: acc rule: less_induct)
 qed
 
 lemma loop_comp_helper_iter_elim_def_n:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    acc :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    x :: nat
   assumes
     non_electing_m: "non_electing m" and
     single_elimination: "eliminates 1 m" and
-    terminate_if_n_left: "\<forall> r. ((t r) \<longleftrightarrow> (card (defer_r r) = x))" and
+    terminate_if_n_left: "\<forall> r. ((t r) = (card (defer_r r) = x))" and
     x_greater_zero: "x > 0" and
     f_prof: "finite_profile A p" and
     acc_defers_enough: "card (defer acc A p) \<ge> x" and
@@ -866,22 +947,28 @@ lemma loop_comp_helper_iter_elim_def_n:
   by (metis (no_types, lifting))
 
 lemma iter_elim_def_n_helper:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    x :: nat
   assumes
     non_electing_m: "non_electing m" and
     single_elimination: "eliminates 1 m" and
-    terminate_if_n_left: "\<forall> r. ((t r) \<longleftrightarrow> (card (defer_r r) = x))" and
+    terminate_if_n_left: "\<forall> r. ((t r) = (card (defer_r r) = x))" and
     x_greater_zero: "x > 0" and
     f_prof: "finite_profile A p" and
     enough_alternatives: "card A \<ge> x"
   shows "card (defer (m \<circlearrowleft>\<^sub>t) A p) = x"
-proof cases
+proof (cases)
   assume "card A = x"
   thus ?thesis
     by (simp add: terminate_if_n_left)
 next
   assume card_not_x: "\<not> card A = x"
   thus ?thesis
-  proof cases
+  proof (cases)
     assume "card A < x"
     thus ?thesis
       using enough_alternatives not_le
@@ -893,7 +980,7 @@ next
       by linarith
     hence card_m: "card (defer m A p) = card A - 1"
       using non_electing_m f_prof single_elimination
-            single_elim_decr_def_card2 x_greater_zero
+            single_elim_decr_def_card_2 x_greater_zero
       by fastforce
     hence card_big_enough_m: "card (defer m A p) \<ge> x"
       using card_big_enough_A
@@ -915,6 +1002,9 @@ text \<open>
 \<close>
 
 theorem loop_comp_presv_def_lift_inv[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition"
   assumes "defer_lift_invariance m"
   shows "defer_lift_invariance (m \<circlearrowleft>\<^sub>t)"
 proof (unfold defer_lift_invariance_def, safe)
@@ -936,7 +1026,7 @@ next
   have defer_lift_loop:
     "\<forall> p q a. (a \<in> (defer (m \<circlearrowleft>\<^sub>t) A p) \<and> lifted A p q a) \<longrightarrow>
         (m \<circlearrowleft>\<^sub>t) A p = (m \<circlearrowleft>\<^sub>t) A q"
-    using assms lifted_imp_fin_prof loop_comp_helper_def_lift_inv2
+    using assms lifted_imp_fin_prof loop_comp_helper_def_lift_inv_2
           loop_composition.simps defer_module.simps
     by (metis (full_types))
   show "(m \<circlearrowleft>\<^sub>t) A p = (m \<circlearrowleft>\<^sub>t) A q"
@@ -949,6 +1039,9 @@ text \<open>
 \<close>
 
 theorem loop_comp_presv_non_electing[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition"
   assumes non_electing_m: "non_electing m"
   shows "non_electing (m \<circlearrowleft>\<^sub>t)"
 proof (unfold non_electing_def, safe, simp_all)
@@ -973,10 +1066,14 @@ next
 qed
 
 theorem iter_elim_def_n[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    t :: "'a Termination_Condition" and
+    n :: nat
   assumes
     non_electing_m: "non_electing m" and
     single_elimination: "eliminates 1 m" and
-    terminate_if_n_left: "\<forall> r. ((t r) \<longleftrightarrow> (card (defer_r r) = n))" and
+    terminate_if_n_left: "\<forall> r. ((t r) = (card (defer_r r) = n))" and
     x_greater_zero: "n > 0"
   shows "defers n (m \<circlearrowleft>\<^sub>t)"
 proof (unfold defers_def, safe)

--- a/theories/Compositional_Structures/Maximum_Parallel_Composition.thy
+++ b/theories/Compositional_Structures/Maximum_Parallel_Composition.thy
@@ -37,6 +37,9 @@ abbreviation max_parallel :: "'a Electoral_Module \<Rightarrow> 'a Electoral_Mod
 subsection \<open>Soundness\<close>
 
 theorem max_par_comp_sound:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     mod_m: "electoral_module m" and
     mod_n: "electoral_module n"
@@ -44,44 +47,50 @@ theorem max_par_comp_sound:
   using mod_m mod_n
   by simp
 
-subsection \<open>Lemmata\<close>
+subsection \<open>Lemmas\<close>
 
 lemma max_agg_eq_result:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
     f_prof: "finite_profile A p" and
-    in_A: "x \<in> A"
+    in_A: "a \<in> A"
   shows
-    "mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p x \<or>
-      mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p x"
+    "mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p a \<or>
+      mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p a"
 proof (cases)
-  assume a1: "x \<in> elect (m \<parallel>\<^sub>\<up> n) A p"
+  assume a_elect: "a \<in> elect (m \<parallel>\<^sub>\<up> n) A p"
     have mod_contains_inst:
-      "\<forall> p_mod q_mod a_set prof a.
-        mod_contains_result p_mod q_mod a_set prof (a::'a) =
+      "\<forall> p_mod q_mod a_set prof b.
+        mod_contains_result p_mod q_mod a_set prof (b::'a) =
           (electoral_module p_mod \<and> electoral_module q_mod \<and>
-            finite a_set \<and> profile a_set prof \<and> a \<in> a_set \<and>
-            (a \<notin> elect p_mod a_set prof \<or> a \<in> elect q_mod a_set prof) \<and>
-            (a \<notin> reject p_mod a_set prof \<or> a \<in> reject q_mod a_set prof) \<and>
-            (a \<notin> defer p_mod a_set prof \<or> a \<in> defer q_mod a_set prof))"
+            finite a_set \<and> profile a_set prof \<and> b \<in> a_set \<and>
+            (b \<notin> elect p_mod a_set prof \<or> b \<in> elect q_mod a_set prof) \<and>
+            (b \<notin> reject p_mod a_set prof \<or> b \<in> reject q_mod a_set prof) \<and>
+            (b \<notin> defer p_mod a_set prof \<or> b \<in> defer q_mod a_set prof))"
       unfolding mod_contains_result_def
       by simp
     have module_mn: "electoral_module (m \<parallel>\<^sub>\<up> n)"
       using module_m module_n
       by simp
-  have not_defer_mn: "x \<notin> defer (m \<parallel>\<^sub>\<up> n) A p"
-    using module_mn IntI a1 empty_iff f_prof result_disj
+  have not_defer_mn: "a \<notin> defer (m \<parallel>\<^sub>\<up> n) A p"
+    using module_mn IntI a_elect empty_iff f_prof result_disj
     by (metis (no_types))
-  have not_reject_mn: "x \<notin> reject (m \<parallel>\<^sub>\<up> n) A p"
-    using module_mn IntI a1 empty_iff f_prof result_disj
+  have not_reject_mn: "a \<notin> reject (m \<parallel>\<^sub>\<up> n) A p"
+    using module_mn IntI a_elect empty_iff f_prof result_disj
     by (metis (no_types))
-  from a1 have
-    "let (e1, r1, d1) = m A p;
-        (e2, r2, d2) = n A p in
-      x \<in> e1 \<union> e2"
+  from a_elect
+  have "let (e1, r1, d1) = m A p;
+           (e2, r2, d2) = n A p in
+         a \<in> e1 \<union> e2"
     by auto
-  hence union_mn: "x \<in> (elect m A p) \<union> (elect n A p)"
+  hence union_mn: "a \<in> (elect m A p) \<union> (elect n A p)"
     by auto
   thus ?thesis
     using f_prof in_A module_m module_mn module_n
@@ -89,14 +98,14 @@ proof (cases)
           mod_contains_inst
       by blast
 next
-  assume not_a1: "x \<notin> elect (m \<parallel>\<^sub>\<up> n) A p"
+  assume not_a_elect: "a \<notin> elect (m \<parallel>\<^sub>\<up> n) A p"
   thus ?thesis
   proof (cases)
-    assume x_in_def: "x \<in> defer (m \<parallel>\<^sub>\<up> n) A p"
+    assume a_in_def: "a \<in> defer (m \<parallel>\<^sub>\<up> n) A p"
     thus ?thesis
     proof (safe)
       assume not_mod_cont_mn:
-        "\<not> mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p x"
+        "\<not> mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p a"
       have par_emod:
         "\<forall> f g.
           (electoral_module (f::'a set \<Rightarrow> 'a Profile \<Rightarrow> 'a Result) \<and>
@@ -111,7 +120,7 @@ next
         "electoral_module (m \<parallel>\<^sub>max_aggregator n)"
         by simp
       have set_intersect:
-        "\<forall>(a::'a) A B. (a \<in> A \<inter> B) = (a \<in> A \<and> a \<in> B)"
+        "\<forall> (b::'a) A B. (b \<in> A \<inter> B) = (b \<in> A \<and> b \<in> B)"
         by blast
       obtain
         s_func :: "('a set \<Rightarrow> 'a Profile \<Rightarrow> 'a Result) \<Rightarrow> 'a set" and
@@ -130,8 +139,6 @@ next
       have wf_m: "well_formed A (m A p)"
         using well_f f_prof module_m
         by blast
-      have a_exists: "\<forall>(a::'a). a \<notin> {}"
-        by blast
       have e_mod_par: "electoral_module (m \<parallel>\<^sub>\<up> n)"
         using par_emod module_m module_n
         by blast
@@ -143,9 +150,9 @@ next
           reject (m \<parallel>\<^sub>max_aggregator n) A p \<inter> defer (m \<parallel>\<^sub>max_aggregator n) A p = {}"
         using f_prof result_disj
         by metis
-      have x_not_elect:
-        "x \<notin> elect (m \<parallel>\<^sub>max_aggregator n) A p"
-        using result_disj_max x_in_def
+      have a_not_elect:
+        "a \<notin> elect (m \<parallel>\<^sub>max_aggregator n) A p"
+        using result_disj_max a_in_def
         by force
       have result_m:
         "(elect m A p, reject m A p, defer m A p) = m A p"
@@ -154,49 +161,49 @@ next
         "(elect n A p, reject n A p, defer n A p) = n A p"
         by auto
       have max_pq:
-        "\<forall>(A::'a set) p q.
-          elect_r (max_aggregator A p q) = elect_r p \<union> elect_r q"
+        "\<forall> (B::'a set) p q.
+          elect_r (max_aggregator B p q) = elect_r p \<union> elect_r q"
         by force
       have
-        "x \<notin> elect (m \<parallel>\<^sub>max_aggregator n) A p"
-        using x_not_elect
+        "a \<notin> elect (m \<parallel>\<^sub>max_aggregator n) A p"
+        using a_not_elect
         by blast
       with max_pq
-      have "x \<notin> elect m A p \<union> elect n A p"
+      have "a \<notin> elect m A p \<union> elect n A p"
         by (simp add: max_pq)
-      hence x_not_elect_mn:
-        "x \<notin> elect m A p \<and> x \<notin> elect n A p"
+      hence b_not_elect_mn:
+        "a \<notin> elect m A p \<and> a \<notin> elect n A p"
         by blast
-      have x_not_mpar_rej:
-        "x \<notin> reject (m \<parallel>\<^sub>max_aggregator n) A p"
-        using result_disj_max x_in_def
+      have b_not_mpar_rej:
+        "a \<notin> reject (m \<parallel>\<^sub>max_aggregator n) A p"
+        using result_disj_max a_in_def
         by fastforce
-      hence x_not_par_rej:
-        "x \<notin> reject (m \<parallel>\<^sub>\<up> n) A p"
+      hence b_not_par_rej:
+        "a \<notin> reject (m \<parallel>\<^sub>\<up> n) A p"
         by auto
       have mod_cont_res_fg:
-        "\<forall> f g A prof (a::'a).
-          mod_contains_result f g A prof a =
+        "\<forall> f g B prof (b::'a).
+          mod_contains_result f g B prof b =
             (electoral_module f \<and> electoral_module g \<and>
-              finite A \<and> profile A prof \<and> a \<in> A \<and>
-                (a \<notin> elect f A prof \<or> a \<in> elect g A prof) \<and>
-                (a \<notin> reject f A prof \<or> a \<in> reject g A prof) \<and>
-                (a \<notin> defer f A prof \<or> a \<in> defer g A prof))"
+              finite B \<and> profile B prof \<and> b \<in> B \<and>
+                (b \<notin> elect f B prof \<or> b \<in> elect g B prof) \<and>
+                (b \<notin> reject f B prof \<or> b \<in> reject g B prof) \<and>
+                (b \<notin> defer f B prof \<or> b \<in> defer g B prof))"
         by (simp add: mod_contains_result_def)
       have max_agg_res:
         "max_aggregator A (elect m A p, reject m A p, defer m A p)
           (elect n A p, reject n A p, defer n A p) = (m \<parallel>\<^sub>max_aggregator n) A p"
         by simp
       have well_f_max:
-        "\<forall> r2 r1 e2 e1 d2 d1 A.
-          well_formed A (e1, r1, d1) \<and> well_formed A (e2, r2, d2) \<longrightarrow>
-            reject_r (max_aggregator A (e1, r1, d1) (e2, r2, d2)) = r1 \<inter> r2"
+        "\<forall> r2 r1 e2 e1 d2 d1 B.
+          well_formed B (e1, r1, d1) \<and> well_formed B (e2, r2, d2) \<longrightarrow>
+            reject_r (max_aggregator B (e1, r1, d1) (e2, r2, d2)) = r1 \<inter> r2"
         using max_agg_rej_set
         by metis
       have e_mod_disj:
-        "\<forall> f (A::'a set) prof.
-          (electoral_module f \<and> finite (A::'a set) \<and> profile A prof) \<longrightarrow>
-            elect f A prof \<union> reject f A prof \<union> defer f A prof = A"
+        "\<forall> f (B::'a set) prof.
+          (electoral_module f \<and> finite (B::'a set) \<and> profile B prof) \<longrightarrow>
+            elect f B prof \<union> reject f B prof \<union> defer f B prof = B"
         using result_presv_alts
         by blast
       hence e_mod_disj_n:
@@ -204,48 +211,47 @@ next
         using f_prof module_n
         by metis
       have
-        "\<forall> f g A prof (a::'a).
-          mod_contains_result f g A prof a =
+        "\<forall> f g B prof (b::'a).
+          mod_contains_result f g B prof b =
             (electoral_module f \<and> electoral_module g \<and>
-              finite A \<and> profile A prof \<and> a \<in> A \<and>
-              (a \<notin> elect f A prof \<or> a \<in> elect g A prof) \<and>
-              (a \<notin> reject f A prof \<or> a \<in> reject g A prof) \<and>
-              (a \<notin> defer f A prof \<or> a \<in> defer g A prof))"
+              finite B \<and> profile B prof \<and> b \<in> B \<and>
+              (b \<notin> elect f B prof \<or> b \<in> elect g B prof) \<and>
+              (b \<notin> reject f B prof \<or> b \<in> reject g B prof) \<and>
+              (b \<notin> defer f B prof \<or> b \<in> defer g B prof))"
         by (simp add: mod_contains_result_def)
       with e_mod_disj_n
-      have "x \<in> reject n A p"
+      have "a \<in> reject n A p"
         using e_mod_par f_prof in_A module_n not_mod_cont_mn
-              x_not_elect x_not_elect_mn x_not_mpar_rej
+              a_not_elect b_not_elect_mn b_not_mpar_rej
         by auto
-      hence "x \<notin> reject m A p"
+      hence "a \<notin> reject m A p"
         using well_f_max max_agg_res result_m result_n
-              set_intersect wf_m wf_n x_not_mpar_rej
+              set_intersect wf_m wf_n b_not_mpar_rej
         by (metis (no_types))
       with max_agg_res
-      have
-        "x \<notin> defer (m \<parallel>\<^sub>\<up> n) A p \<or> x \<in> defer m A p"
-          using e_mod_disj f_prof in_A module_m x_not_elect_mn
+      have "a \<notin> defer (m \<parallel>\<^sub>\<up> n) A p \<or> a \<in> defer m A p"
+          using e_mod_disj f_prof in_A module_m b_not_elect_mn
           by blast
-      with x_not_mpar_rej
-      show "mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p x"
-        using mod_cont_res_fg x_not_par_rej e_mod_par f_prof
-              in_A module_m x_not_elect
+      with b_not_mpar_rej
+      show "mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p a"
+        using mod_cont_res_fg b_not_par_rej e_mod_par f_prof
+              in_A module_m a_not_elect
         by auto
     qed
   next
-    assume not_a2: "x \<notin> defer (m \<parallel>\<^sub>\<up> n) A p"
+    assume not_a_defer: "a \<notin> defer (m \<parallel>\<^sub>\<up> n) A p"
     have el_rej_defer:
       "(elect m A p, reject m A p, defer m A p) = m A p"
       by auto
-    from not_a1 not_a2 have a3:
-      "x \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
+    from not_a_elect not_a_defer
+    have a_reject: "a \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
       using electoral_mod_defer_elem in_A module_m module_n
             f_prof max_par_comp_sound
       by metis
     hence
       "case snd (m A p) of (Aa, Ab) \<Rightarrow>
         case n A p of (Ac, Ad, Ae) \<Rightarrow>
-          x \<in> reject_r
+          a \<in> reject_r
             (max_aggregator A
               (elect m A p, Aa, Ab) (Ac, Ad, Ae))"
       using el_rej_defer
@@ -253,82 +259,94 @@ next
     hence
       "let (e1, r1, d1) = m A p;
           (e2, r2, d2) = n A p in
-        x \<in> fst (snd (max_aggregator A
+        a \<in> fst (snd (max_aggregator A
           (e1, r1, d1) (e2, r2, d2)))"
       by (simp add: case_prod_unfold)
     hence
       "let (e1, r1, d1) = m A p;
           (e2, r2, d2) = n A p in
-        x \<in> A - (e1 \<union> e2 \<union> d1 \<union> d2)"
+        a \<in> A - (e1 \<union> e2 \<union> d1 \<union> d2)"
       by simp
-    hence "x \<notin> elect m A p \<union> (defer n A p \<union> defer m A p)"
+    hence "a \<notin> elect m A p \<union> (defer n A p \<union> defer m A p)"
       by force
     thus ?thesis
       using mod_contains_result_comm mod_contains_result_def Un_iff
-            a3 f_prof in_A module_m module_n max_par_comp_sound
+            a_reject f_prof in_A module_m module_n max_par_comp_sound
       by (metis (no_types))
   qed
 qed
 
 lemma max_agg_rej_iff_both_reject:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
     f_prof: "finite_profile A p" and
     module_m: "electoral_module m" and
     module_n: "electoral_module n"
   shows
-    "x \<in> reject (m \<parallel>\<^sub>\<up> n) A p \<longleftrightarrow>
-      (x \<in> reject m A p \<and> x \<in> reject n A p)"
+    "(a \<in> reject (m \<parallel>\<^sub>\<up> n) A p) =
+      (a \<in> reject m A p \<and> a \<in> reject n A p)"
 proof
-  assume a: "x \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
+  assume rej_a: "a \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
   hence
     "case n A p of (Aa, Ab, Ac) \<Rightarrow>
-      x \<in> reject_r (max_aggregator A
+      a \<in> reject_r (max_aggregator A
         (elect m A p, reject m A p, defer m A p) (Aa, Ab, Ac))"
     by auto
   hence
     "case snd (m A p) of (Aa, Ab) \<Rightarrow>
       case n A p of (Ac, Ad, Ae) \<Rightarrow>
-        x \<in> reject_r (max_aggregator A
+        a \<in> reject_r (max_aggregator A
           (elect m A p, Aa, Ab) (Ac, Ad, Ae))"
     by force
-  with a have
+  with rej_a have
     "let (e1, r1, d1) = m A p;
           (e2, r2, d2) = n A p in
-      x \<in> fst (snd (max_aggregator A (e1, r1, d1) (e2, r2, d2)))"
+      a \<in> fst (snd (max_aggregator A (e1, r1, d1) (e2, r2, d2)))"
     by (simp add: prod.case_eq_if)
   hence
     "let (e1, r1, d1) = m A p;
         (e2, r2, d2) = n A p in
-      x \<in> A - (e1 \<union> e2 \<union> d1 \<union> d2)"
+      a \<in> A - (e1 \<union> e2 \<union> d1 \<union> d2)"
     by simp
   hence
-    "x \<in> A - (elect m A p \<union> elect n A p \<union> defer m A p \<union> defer n A p)"
+    "a \<in> A - (elect m A p \<union> elect n A p \<union> defer m A p \<union> defer n A p)"
     by auto
-  thus "x \<in> reject m A p \<and> x \<in> reject n A p"
+  thus "a \<in> reject m A p \<and> a \<in> reject n A p"
     using Diff_iff Un_iff electoral_mod_defer_elem
           f_prof module_m module_n
     by metis
 next
-  assume a: "x \<in> reject m A p \<and> x \<in> reject n A p"
+  assume a: "a \<in> reject m A p \<and> a \<in> reject n A p"
   hence
-    "x \<notin> elect m A p \<and> x \<notin> defer m A p \<and>
-      x \<notin> elect n A p \<and> x \<notin> defer n A p"
+    "a \<notin> elect m A p \<and> a \<notin> defer m A p \<and>
+      a \<notin> elect n A p \<and> a \<notin> defer n A p"
     using IntI empty_iff module_m module_n f_prof result_disj
     by metis
-  thus "x \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
+  thus "a \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
     using DiffD1 a f_prof max_agg_eq_result module_m module_n
           mod_contains_result_comm mod_contains_result_def
           reject_not_elec_or_def
       by (metis (no_types))
 qed
 
-lemma max_agg_rej1:
+lemma max_agg_rej_1:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
     f_prof: "finite_profile A p" and
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
-    rejected: "x \<in> reject n A p"
-  shows "mod_contains_result m (m \<parallel>\<^sub>\<up> n) A p x"
+    rejected: "a \<in> reject n A p"
+  shows "mod_contains_result m (m \<parallel>\<^sub>\<up> n) A p a"
 proof (unfold mod_contains_result_def, safe)
   show "electoral_module m"
     using module_m
@@ -346,48 +364,44 @@ next
     using f_prof
     by simp
 next
-  show "x \<in> A"
+  show "a \<in> A"
     using f_prof module_n reject_in_alts rejected
     by auto
 next
-  assume x_in_elect: "x \<in> elect m A p"
-  hence x_not_reject:
-    "x \<notin> reject m A p"
+  assume a_in_elect: "a \<in> elect m A p"
+  hence a_not_reject: "a \<notin> reject m A p"
     using disjoint_iff_not_equal f_prof module_m result_disj
     by metis
-  have rej_in_A:
-    "reject n A p \<subseteq> A"
+  have rej_in_A: "reject n A p \<subseteq> A"
     using f_prof module_n
     by (simp add: reject_in_alts)
-  have x_in_A: "x \<in> A"
+  have a_in_A: "a \<in> A"
     using rej_in_A in_mono rejected
     by metis
-  with x_in_elect x_not_reject
-  show "x \<in> elect (m \<parallel>\<^sub>\<up> n) A p"
+  with a_in_elect a_not_reject
+  show "a \<in> elect (m \<parallel>\<^sub>\<up> n) A p"
     using f_prof max_agg_eq_result module_m module_n rejected
           max_agg_rej_iff_both_reject mod_contains_result_comm
           mod_contains_result_def
       by metis
 next
-  assume "x \<in> reject m A p"
-  hence
-    "x \<in> reject m A p \<and> x \<in> reject n A p"
+  assume "a \<in> reject m A p"
+  hence "a \<in> reject m A p \<and> a \<in> reject n A p"
     using rejected
     by simp
-  thus "x \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
+  thus "a \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
     using f_prof max_agg_rej_iff_both_reject module_m module_n
     by (metis (no_types))
 next
-  assume x_in_defer: "x \<in> defer m A p"
+  assume a_in_defer: "a \<in> defer m A p"
   hence defer_a:
-    "\<exists> a. a \<in> defer m A p \<and> x = a"
+    "\<exists> b. b \<in> defer m A p \<and> b = a"
     by simp
-  then obtain x_inst :: 'a where
-    inst_x: "x = x_inst \<and> x_inst \<in> defer m A p"
+  then obtain a_inst :: 'a where
+    inst_a: "a = a_inst \<and> a_inst \<in> defer m A p"
     by metis
-  hence x_not_rej:
-    "x \<notin> reject m A p"
-    using disjoint_iff_not_equal f_prof inst_x module_m result_disj
+  hence a_not_rej: "a \<notin> reject m A p"
+    using disjoint_iff_not_equal f_prof inst_a module_m result_disj
     by (metis (no_types))
   have
     "\<forall> f A prof.
@@ -395,38 +409,48 @@ next
         elect f A prof \<union> reject f A prof \<union> defer f A prof = A"
     using result_presv_alts
     by metis
-  with x_in_defer
-  have "x \<in> A"
+  with a_in_defer
+  have "a \<in> A"
     using f_prof module_m
     by blast
-  with inst_x x_not_rej
-  show "x \<in> defer (m \<parallel>\<^sub>\<up> n) A p"
-    using f_prof max_agg_eq_result
-          max_agg_rej_iff_both_reject
-          mod_contains_result_comm
-          mod_contains_result_def
+  with inst_a a_not_rej
+  show "a \<in> defer (m \<parallel>\<^sub>\<up> n) A p"
+    using f_prof max_agg_eq_result max_agg_rej_iff_both_reject
+          mod_contains_result_comm mod_contains_result_def
           module_m module_n rejected
     by metis
 qed
 
-lemma max_agg_rej2:
+lemma max_agg_rej_2:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
     f_prof: "finite_profile A p" and
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
-    rejected: "x \<in> reject n A p"
-  shows "mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p x"
-  using mod_contains_result_comm max_agg_rej1
+    rejected: "a \<in> reject n A p"
+  shows "mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p a"
+  using mod_contains_result_comm max_agg_rej_1
         module_m module_n f_prof rejected
   by metis
 
-lemma max_agg_rej3:
+lemma max_agg_rej_3:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
     f_prof:  "finite_profile A p" and
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
-    rejected: "x \<in> reject m A p"
-  shows "mod_contains_result n (m \<parallel>\<^sub>\<up> n) A p x"
+    rejected: "a \<in> reject m A p"
+  shows "mod_contains_result n (m \<parallel>\<^sub>\<up> n) A p a"
 proof (unfold mod_contains_result_def, safe)
   show "electoral_module n"
     using module_n
@@ -444,47 +468,58 @@ next
     using f_prof
     by simp
 next
-  show "x \<in> A"
+  show "a \<in> A"
     using f_prof in_mono module_m reject_in_alts rejected
     by (metis (no_types))
 next
-  assume "x \<in> elect n A p"
-  thus "x \<in> elect (m \<parallel>\<^sub>\<up> n) A p"
+  assume "a \<in> elect n A p"
+  thus "a \<in> elect (m \<parallel>\<^sub>\<up> n) A p"
     using Un_iff combine_ele_rej_def fst_conv
           maximum_parallel_composition.simps
           max_aggregator.simps
     unfolding parallel_composition.simps
     by (metis (mono_tags, lifting))
 next
-  assume "x \<in> reject n A p"
-  thus "x \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
+  assume "a \<in> reject n A p"
+  thus "a \<in> reject (m \<parallel>\<^sub>\<up> n) A p"
     using f_prof max_agg_rej_iff_both_reject module_m module_n rejected
     by metis
 next
-  assume x_in_def: "x \<in> defer n A p"
-  have "x \<in> A"
-    using f_prof max_agg_rej1 mod_contains_result_def module_m rejected
+  assume a_in_def: "a \<in> defer n A p"
+  have "a \<in> A"
+    using f_prof max_agg_rej_1 mod_contains_result_def module_m rejected
     by metis
-  thus "x \<in> defer (m \<parallel>\<^sub>\<up> n) A p"
-    using x_in_def disjoint_iff_not_equal f_prof
+  thus "a \<in> defer (m \<parallel>\<^sub>\<up> n) A p"
+    using a_in_def disjoint_iff_not_equal f_prof
           max_agg_eq_result max_agg_rej_iff_both_reject
           mod_contains_result_comm mod_contains_result_def
           module_m module_n rejected result_disj
       by metis
 qed
 
-lemma max_agg_rej4:
+lemma max_agg_rej_4:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
   assumes
     f_prof: "finite_profile A p" and
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
-    rejected: "x \<in> reject m A p"
-  shows "mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p x"
-  using mod_contains_result_comm max_agg_rej3
+    rejected: "a \<in> reject m A p"
+  shows "mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p a"
+  using mod_contains_result_comm max_agg_rej_3
         module_m module_n f_prof rejected
   by metis
 
 lemma max_agg_rej_intersect:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
@@ -515,15 +550,20 @@ proof -
 qed
 
 lemma dcompat_dec_by_one_mod:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    a :: "'a"
   assumes
     compatible: "disjoint_compatibility m n" and
-    in_A: "x \<in> A"
+    in_A: "a \<in> A"
   shows
     "(\<forall> p. finite_profile A p \<longrightarrow>
-          mod_contains_result m (m \<parallel>\<^sub>\<up> n) A p x) \<or>
+          mod_contains_result m (m \<parallel>\<^sub>\<up> n) A p a) \<or>
         (\<forall> p. finite_profile A p \<longrightarrow>
-          mod_contains_result n (m \<parallel>\<^sub>\<up> n) A p x)"
-  using DiffI compatible in_A max_agg_rej1 max_agg_rej3
+          mod_contains_result n (m \<parallel>\<^sub>\<up> n) A p a)"
+  using DiffI compatible in_A max_agg_rej_1 max_agg_rej_3
   unfolding disjoint_compatibility_def
   by metis
 
@@ -535,6 +575,9 @@ text \<open>
 \<close>
 
 theorem conserv_max_agg_presv_non_electing[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     non_electing_m: "non_electing m" and
     non_electing_n: "non_electing n"
@@ -548,6 +591,9 @@ text \<open>
 \<close>
 
 theorem par_comp_def_lift_inv[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     compatible: "disjoint_compatibility m n" and
     monotone_m: "defer_lift_invariance m" and
@@ -567,191 +613,191 @@ proof (unfold defer_lift_invariance_def, safe)
     by simp
 next
   fix
-    S :: "'a set" and
+    A :: "'a set" and
     p :: "'a Profile" and
     q :: "'a Profile" and
-    x :: "'a"
+    a :: "'a"
   assume
-    defer_x: "x \<in> defer (m \<parallel>\<^sub>\<up> n) S p" and
-    lifted_x: "Profile.lifted S p q x"
-  hence f_profs: "finite_profile S p \<and> finite_profile S q"
+    defer_a: "a \<in> defer (m \<parallel>\<^sub>\<up> n) A p" and
+    lifted_a: "Profile.lifted A p q a"
+  hence f_profs: "finite_profile A p \<and> finite_profile A q"
     unfolding lifted_def
     by simp
   from compatible
-  obtain A :: "'a set" where A:
-    "A \<subseteq> S \<and> (\<forall> x \<in> A. indep_of_alt m S x \<and>
-      (\<forall> p. finite_profile S p \<longrightarrow> x \<in> reject m S p)) \<and>
-        (\<forall> x \<in> S - A. indep_of_alt n S x \<and>
-      (\<forall> p. finite_profile S p \<longrightarrow> x \<in> reject n S p))"
+  obtain B :: "'a set" where
+    alts: "B \<subseteq> A \<and> (\<forall> x \<in> B. indep_of_alt m A x \<and>
+            (\<forall> p. finite_profile A p \<longrightarrow> x \<in> reject m A p)) \<and>
+              (\<forall> x \<in> A - B. indep_of_alt n A x \<and>
+            (\<forall> p. finite_profile A p \<longrightarrow> x \<in> reject n A p))"
     using f_profs
     unfolding disjoint_compatibility_def
     by (metis (no_types, lifting))
-  have "\<forall> x \<in> S. prof_contains_result (m \<parallel>\<^sub>\<up> n) S p q x"
+  have "\<forall> x \<in> A. prof_contains_result (m \<parallel>\<^sub>\<up> n) A p q x"
   proof (cases)
-    assume a0: "x \<in> A"
-    hence "x \<in> reject m S p"
-      using A f_profs
+    assume a0: "a \<in> B"
+    hence "a \<in> reject m A p"
+      using alts f_profs
       by blast
-    with defer_x
-    have defer_n: "x \<in> defer n S p"
-      using compatible f_profs max_agg_rej4
+    with defer_a
+    have defer_n: "a \<in> defer n A p"
+      using compatible f_profs max_agg_rej_4
       unfolding disjoint_compatibility_def mod_contains_result_def
       by metis
-    have "\<forall> x \<in> A. mod_contains_result (m \<parallel>\<^sub>\<up> n) n S p x"
-      using A compatible max_agg_rej4 f_profs
+    have "\<forall> x \<in> B. mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p x"
+      using alts compatible max_agg_rej_4 f_profs
       unfolding disjoint_compatibility_def
       by metis
-    moreover have "\<forall> x \<in> S. prof_contains_result n S p q x"
+    moreover have "\<forall> x \<in> A. prof_contains_result n A p q x"
     proof (unfold prof_contains_result_def, clarify)
-      fix x :: "'a"
-      assume x_in_S: "x \<in> S"
+      fix b :: "'a"
+      assume b_in_A: "b \<in> A"
       show
         "electoral_module n \<and>
-         finite_profile S p \<and>
-         finite_profile S q \<and>
-         x \<in> S \<and>
-         (x \<in> elect n S p \<longrightarrow> x \<in> elect n S q) \<and>
-         (x \<in> reject n S p \<longrightarrow> x \<in> reject n S q) \<and>
-         (x \<in> defer n S p \<longrightarrow> x \<in> defer n S q)"
+         finite_profile A p \<and>
+         finite_profile A q \<and>
+         b \<in> A \<and>
+         (b \<in> elect n A p \<longrightarrow> b \<in> elect n A q) \<and>
+         (b \<in> reject n A p \<longrightarrow> b \<in> reject n A q) \<and>
+         (b \<in> defer n A p \<longrightarrow> b \<in> defer n A q)"
       proof (safe)
         show "electoral_module n"
           using monotone_n
           unfolding defer_lift_invariance_def
           by metis
       next
-        show "finite S"
+        show "finite A"
           using f_profs
           by simp
       next
-        show "profile S p"
+        show "profile A p"
           using f_profs
           by simp
       next
-        show "finite S"
+        show "finite A"
           using f_profs
           by simp
       next
-        show "profile S q"
+        show "profile A q"
           using f_profs
           by simp
       next
-        show "x \<in> S"
-          using x_in_S
+        show "b \<in> A"
+          using b_in_A
           by simp
       next
-        assume "x \<in> elect n S p"
-        thus "x \<in> elect n S q"
-          using defer_n lifted_x monotone_n f_profs
+        assume "b \<in> elect n A p"
+        thus "b \<in> elect n A q"
+          using defer_n lifted_a monotone_n f_profs
           unfolding defer_lift_invariance_def
           by metis
       next
-        assume "x \<in> reject n S p"
-        thus "x \<in> reject n S q"
-          using defer_n lifted_x monotone_n f_profs
+        assume "b \<in> reject n A p"
+        thus "b \<in> reject n A q"
+          using defer_n lifted_a monotone_n f_profs
           unfolding defer_lift_invariance_def
           by metis
       next
-        assume "x \<in> defer n S p"
-        thus "x \<in> defer n S q"
-          using defer_n lifted_x monotone_n f_profs
+        assume "b \<in> defer n A p"
+        thus "b \<in> defer n A q"
+          using defer_n lifted_a monotone_n f_profs
           unfolding defer_lift_invariance_def
           by metis
       qed
     qed
     moreover have
-      "\<forall> x \<in> A. mod_contains_result n (m \<parallel>\<^sub>\<up> n) S q x"
-      using A compatible max_agg_rej3 f_profs
+      "\<forall> x \<in> B. mod_contains_result n (m \<parallel>\<^sub>\<up> n) A q x"
+      using alts compatible max_agg_rej_3 f_profs
       unfolding disjoint_compatibility_def
       by metis
     ultimately have 00:
-      "\<forall> x \<in> A. prof_contains_result (m \<parallel>\<^sub>\<up> n) S p q x"
+      "\<forall> x \<in> B. prof_contains_result (m \<parallel>\<^sub>\<up> n) A p q x"
       unfolding mod_contains_result_def prof_contains_result_def
       by simp
     have
-      "\<forall> x \<in> S - A. mod_contains_result (m \<parallel>\<^sub>\<up> n) m S p x"
-      using A max_agg_rej2 monotone_m monotone_n f_profs
+      "\<forall> x \<in> A - B. mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p x"
+      using alts max_agg_rej_2 monotone_m monotone_n f_profs
       unfolding defer_lift_invariance_def
       by metis
-    moreover have "\<forall> x \<in> S. prof_contains_result m S p q x"
+    moreover have "\<forall> x \<in> A. prof_contains_result m A p q x"
     proof (unfold prof_contains_result_def, clarify)
-      fix x :: "'a"
-      assume x_in_S: "x \<in> S"
+      fix b :: "'a"
+      assume b_in_A: "b \<in> A"
       show
         "electoral_module m \<and>
-         finite_profile S p \<and>
-         finite_profile S q \<and>
-         x \<in> S \<and>
-         (x \<in> elect m S p \<longrightarrow> x \<in> elect m S q) \<and>
-         (x \<in> reject m S p \<longrightarrow> x \<in> reject m S q) \<and>
-         (x \<in> defer m S p \<longrightarrow> x \<in> defer m S q)"
+         finite_profile A p \<and>
+         finite_profile A q \<and>
+         b \<in> A \<and>
+         (b \<in> elect m A p \<longrightarrow> b \<in> elect m A q) \<and>
+         (b \<in> reject m A p \<longrightarrow> b \<in> reject m A q) \<and>
+         (b \<in> defer m A p \<longrightarrow> b \<in> defer m A q)"
       proof (safe)
         show "electoral_module m"
           using monotone_m
           unfolding defer_lift_invariance_def
           by metis
       next
-        show "finite S"
+        show "finite A"
           using f_profs
           by simp
       next
-        show "profile S p"
+        show "profile A p"
           using f_profs
           by simp
       next
-        show "finite S"
+        show "finite A"
           using f_profs
           by simp
       next
-        show "profile S q"
+        show "profile A q"
           using f_profs
           by simp
       next
-        show "x \<in> S"
-          using x_in_S
+        show "b \<in> A"
+          using b_in_A
           by simp
       next
-        assume "x \<in> elect m S p"
-        thus "x \<in> elect m S q"
-          using A a0 lifted_x lifted_imp_equiv_prof_except_a
+        assume "b \<in> elect m A p"
+        thus "b \<in> elect m A q"
+          using alts a0 lifted_a lifted_imp_equiv_prof_except_a
           unfolding indep_of_alt_def
           by metis
       next
-        assume "x \<in> reject m S p"
-        thus "x \<in> reject m S q"
-          using A a0 lifted_x lifted_imp_equiv_prof_except_a
+        assume "b \<in> reject m A p"
+        thus "b \<in> reject m A q"
+          using alts a0 lifted_a lifted_imp_equiv_prof_except_a
           unfolding indep_of_alt_def
           by metis
       next
-        assume "x \<in> defer m S p"
-        thus "x \<in> defer m S q"
-          using A a0 lifted_x lifted_imp_equiv_prof_except_a
+        assume "b \<in> defer m A p"
+        thus "b \<in> defer m A q"
+          using alts a0 lifted_a lifted_imp_equiv_prof_except_a
           unfolding indep_of_alt_def
           by metis
       qed
     qed
     moreover have
-      "\<forall> x \<in> S - A. mod_contains_result m (m \<parallel>\<^sub>\<up> n) S q x"
-      using A max_agg_rej1 monotone_m monotone_n f_profs
+      "\<forall> x \<in> A - B. mod_contains_result m (m \<parallel>\<^sub>\<up> n) A q x"
+      using alts max_agg_rej_1 monotone_m monotone_n f_profs
       unfolding defer_lift_invariance_def
       by metis
     ultimately have 01:
-      "\<forall> x \<in> S - A. prof_contains_result (m \<parallel>\<^sub>\<up> n) S p q x"
+      "\<forall> x \<in> A - B. prof_contains_result (m \<parallel>\<^sub>\<up> n) A p q x"
       unfolding mod_contains_result_def prof_contains_result_def
       by simp
     from 00 01
     show ?thesis
       by blast
   next
-    assume "x \<notin> A"
-    hence a1: "x \<in> S - A"
-      using DiffI lifted_x compatible f_profs
+    assume "a \<notin> B"
+    hence a_in_set_diff: "a \<in> A - B"
+      using DiffI lifted_a compatible f_profs
       unfolding Profile.lifted_def
       by (metis (no_types, lifting))
-    hence "x \<in> reject n S p"
-      using A f_profs
+    hence "a \<in> reject n A p"
+      using alts f_profs
       by blast
-    with defer_x
-    have defer_m: "x \<in> defer m S p"
+    with defer_a
+    have defer_m: "a \<in> defer m A p"
       using DiffD1 DiffD2 compatible dcompat_dec_by_one_mod f_profs
             defer_not_elec_or_rej max_agg_sound par_comp_sound
             disjoint_compatibility_def not_rej_imp_elec_or_def
@@ -759,143 +805,143 @@ next
       unfolding maximum_parallel_composition.simps
       by metis
     have
-      "\<forall> x \<in> A. mod_contains_result (m \<parallel>\<^sub>\<up> n) n S p x"
-      using A compatible max_agg_rej4 f_profs
+      "\<forall> x \<in> B. mod_contains_result (m \<parallel>\<^sub>\<up> n) n A p x"
+      using alts compatible max_agg_rej_4 f_profs
       unfolding disjoint_compatibility_def
       by metis
-    moreover have "\<forall> x \<in> S. prof_contains_result n S p q x"
+    moreover have "\<forall> x \<in> A. prof_contains_result n A p q x"
     proof (unfold prof_contains_result_def, clarify)
-      fix x :: "'a"
-      assume x_in_S: "x \<in> S"
+      fix b :: "'a"
+      assume b_in_A: "b \<in> A"
       show
         "electoral_module n \<and>
-         finite_profile S p \<and>
-         finite_profile S q \<and>
-         x \<in> S \<and>
-         (x \<in> elect n S p \<longrightarrow> x \<in> elect n S q) \<and>
-         (x \<in> reject n S p \<longrightarrow> x \<in> reject n S q) \<and>
-         (x \<in> defer n S p \<longrightarrow> x \<in> defer n S q)"
+         finite_profile A p \<and>
+         finite_profile A q \<and>
+         b \<in> A \<and>
+         (b \<in> elect n A p \<longrightarrow> b \<in> elect n A q) \<and>
+         (b \<in> reject n A p \<longrightarrow> b \<in> reject n A q) \<and>
+         (b \<in> defer n A p \<longrightarrow> b \<in> defer n A q)"
       proof (safe)
         show "electoral_module n"
           using monotone_n
           unfolding defer_lift_invariance_def
           by metis
       next
-        show "finite S"
+        show "finite A"
           using f_profs
           by simp
       next
-        show "profile S p"
+        show "profile A p"
           using f_profs
           by simp
       next
-        show "finite S"
+        show "finite A"
           using f_profs
           by simp
       next
-        show "profile S q"
+        show "profile A q"
           using f_profs
           by simp
       next
-        show "x \<in> S"
-          using x_in_S
+        show "b \<in> A"
+          using b_in_A
           by simp
       next
-        assume "x \<in> elect n S p"
-        thus "x \<in> elect n S q"
-          using A a1 lifted_x lifted_imp_equiv_prof_except_a
+        assume "b \<in> elect n A p"
+        thus "b \<in> elect n A q"
+          using alts a_in_set_diff lifted_a lifted_imp_equiv_prof_except_a
           unfolding indep_of_alt_def
           by metis
       next
-        assume "x \<in> reject n S p"
-        thus "x \<in> reject n S q"
-          using A a1 lifted_x lifted_imp_equiv_prof_except_a
+        assume "b \<in> reject n A p"
+        thus "b \<in> reject n A q"
+          using alts a_in_set_diff lifted_a lifted_imp_equiv_prof_except_a
           unfolding indep_of_alt_def
           by metis
       next
-        assume "x \<in> defer n S p"
-        thus "x \<in> defer n S q"
-          using A a1 lifted_x lifted_imp_equiv_prof_except_a
+        assume "b \<in> defer n A p"
+        thus "b \<in> defer n A q"
+          using alts a_in_set_diff lifted_a lifted_imp_equiv_prof_except_a
           unfolding indep_of_alt_def
           by metis
       qed
   qed
-  moreover have "\<forall> x \<in> A. mod_contains_result n (m \<parallel>\<^sub>\<up> n) S q x"
-    using A compatible max_agg_rej3 f_profs
+  moreover have "\<forall> x \<in> B. mod_contains_result n (m \<parallel>\<^sub>\<up> n) A q x"
+    using alts compatible max_agg_rej_3 f_profs
     unfolding disjoint_compatibility_def
     by metis
   ultimately have 10:
-    "\<forall> x \<in> A. prof_contains_result (m \<parallel>\<^sub>\<up> n) S p q x"
+    "\<forall> x \<in> B. prof_contains_result (m \<parallel>\<^sub>\<up> n) A p q x"
     unfolding mod_contains_result_def prof_contains_result_def
     by simp
-  have "\<forall> x \<in> S - A. mod_contains_result (m \<parallel>\<^sub>\<up> n) m S p x"
-    using A max_agg_rej2 monotone_m monotone_n f_profs
+  have "\<forall> x \<in> A - B. mod_contains_result (m \<parallel>\<^sub>\<up> n) m A p x"
+    using alts max_agg_rej_2 monotone_m monotone_n f_profs
     unfolding defer_lift_invariance_def
     by metis
-  moreover have "\<forall> x \<in> S. prof_contains_result m S p q x"
+  moreover have "\<forall> x \<in> A. prof_contains_result m A p q x"
   proof (unfold prof_contains_result_def, clarify)
-    fix x :: "'a"
-    assume x_in_S: "x \<in> S"
+    fix b :: "'a"
+    assume b_in_A: "b \<in> A"
     show
       "electoral_module m \<and>
-        finite_profile S p \<and>
-        finite_profile S q \<and>
-        x \<in> S \<and>
-        (x \<in> elect m S p \<longrightarrow> x \<in> elect m S q) \<and>
-        (x \<in> reject m S p \<longrightarrow> x \<in> reject m S q) \<and>
-        (x \<in> defer m S p \<longrightarrow> x \<in> defer m S q)"
+        finite_profile A p \<and>
+        finite_profile A q \<and>
+        b \<in> A \<and>
+        (b \<in> elect m A p \<longrightarrow> b \<in> elect m A q) \<and>
+        (b \<in> reject m A p \<longrightarrow> b \<in> reject m A q) \<and>
+        (b \<in> defer m A p \<longrightarrow> b \<in> defer m A q)"
     proof (safe)
       show "electoral_module m"
         using monotone_m
         unfolding defer_lift_invariance_def
         by simp
     next
-      show "finite S"
+      show "finite A"
         using f_profs
         by simp
     next
-      show "profile S p"
+      show "profile A p"
         using f_profs
         by simp
     next
-      show "finite S"
+      show "finite A"
         using f_profs
         by simp
     next
-      show "profile S q"
+      show "profile A q"
         using f_profs
         by simp
     next
-      show "x \<in> S"
-        using x_in_S
+      show "b \<in> A"
+        using b_in_A
         by simp
     next
-      assume "x \<in> elect m S p"
-      thus "x \<in> elect m S q"
-        using defer_m lifted_x monotone_m
+      assume "b \<in> elect m A p"
+      thus "b \<in> elect m A q"
+        using defer_m lifted_a monotone_m
         unfolding defer_lift_invariance_def
         by metis
     next
-      assume "x \<in> reject m S p"
-      thus "x \<in> reject m S q"
-        using defer_m lifted_x monotone_m
+      assume "b \<in> reject m A p"
+      thus "b \<in> reject m A q"
+        using defer_m lifted_a monotone_m
         unfolding defer_lift_invariance_def
         by metis
     next
-      assume "x \<in> defer m S p"
-      thus "x \<in> defer m S q"
-        using defer_m lifted_x monotone_m
+      assume "b \<in> defer m A p"
+      thus "b \<in> defer m A q"
+        using defer_m lifted_a monotone_m
         unfolding defer_lift_invariance_def
         by metis
     qed
   qed
   moreover have
-    "\<forall> x \<in> S - A. mod_contains_result m (m \<parallel>\<^sub>\<up> n) S q x"
-    using A max_agg_rej1 monotone_m monotone_n f_profs
+    "\<forall> x \<in> A - B. mod_contains_result m (m \<parallel>\<^sub>\<up> n) A q x"
+    using alts max_agg_rej_1 monotone_m monotone_n f_profs
     unfolding defer_lift_invariance_def
     by metis
   ultimately have 11:
-    "\<forall> x \<in> S - A. prof_contains_result (m \<parallel>\<^sub>\<up> n) S p q x"
+    "\<forall> x \<in> A - B. prof_contains_result (m \<parallel>\<^sub>\<up> n) A p q x"
     using electoral_mod_defer_elem
     unfolding mod_contains_result_def prof_contains_result_def
     by simp
@@ -903,7 +949,7 @@ next
   show ?thesis
     by blast
   qed
-  thus "(m \<parallel>\<^sub>\<up> n) S p = (m \<parallel>\<^sub>\<up> n) S q"
+  thus "(m \<parallel>\<^sub>\<up> n) A p = (m \<parallel>\<^sub>\<up> n) A q"
     using compatible f_profs eq_alts_in_profs_imp_eq_results
           max_par_comp_sound
     unfolding disjoint_compatibility_def
@@ -911,51 +957,59 @@ next
 qed
 
 lemma par_comp_rej_card:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    c :: nat
   assumes
-    compatible: "disjoint_compatibility x y" and
-    f_prof: "finite_profile S p" and
-    reject_sum: "card (reject x S p) + card (reject y S p) = card S + n"
-  shows "card (reject (x \<parallel>\<^sub>\<up> y) S p) = n"
+    compatible: "disjoint_compatibility m n" and
+    f_prof: "finite_profile A p" and
+    reject_sum: "card (reject m A p) + card (reject n A p) = card A + c"
+  shows "card (reject (m \<parallel>\<^sub>\<up> n) A p) = c"
 proof -
-  from compatible obtain A where A:
-    "A \<subseteq> S \<and>
-      (\<forall> a \<in> A. indep_of_alt x S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject x S p)) \<and>
-      (\<forall> a \<in> S - A. indep_of_alt y S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject y S p))"
+  from compatible
+  obtain B where
+    alt_set: "B \<subseteq> A \<and>
+         (\<forall> a \<in> B. indep_of_alt m A a \<and>
+             (\<forall> q. finite_profile A q \<longrightarrow> a \<in> reject m A q)) \<and>
+         (\<forall> a \<in> A - B. indep_of_alt n A a \<and>
+             (\<forall> q. finite_profile A q \<longrightarrow> a \<in> reject n A q))"
     using f_prof
     unfolding disjoint_compatibility_def
     by metis
-  from f_prof compatible have reject_representation:
-    "reject (x \<parallel>\<^sub>\<up> y) S p = (reject x S p) \<inter> (reject y S p)"
+  from f_prof compatible
+  have reject_representation:
+    "reject (m \<parallel>\<^sub>\<up> n) A p = (reject m A p) \<inter> (reject n A p)"
     using max_agg_rej_intersect
     unfolding disjoint_compatibility_def
     by metis
-  have "electoral_module x \<and> electoral_module y"
+  have "electoral_module m \<and> electoral_module n"
     using compatible
     unfolding disjoint_compatibility_def
     by simp
-  hence subsets: "(reject x S p) \<subseteq> S \<and> (reject y S p) \<subseteq> S"
+  hence subsets: "(reject m A p) \<subseteq> A \<and> (reject n A p) \<subseteq> A"
     by (simp add: f_prof reject_in_alts)
-  hence "finite (reject x S p) \<and> finite (reject y S p)"
+  hence "finite (reject m A p) \<and> finite (reject n A p)"
     using rev_finite_subset f_prof
     by metis
   hence 0:
-    "card (reject (x \<parallel>\<^sub>\<up> y) S p) =
-        card S + n -
-          card ((reject x S p) \<union> (reject y S p))"
+    "card (reject (m \<parallel>\<^sub>\<up> n) A p) =
+        card A + c -
+          card ((reject m A p) \<union> (reject n A p))"
     using card_Un_Int reject_representation reject_sum
     by fastforce
-  have "\<forall> a \<in> S. a \<in> (reject x S p) \<or> a \<in> (reject y S p)"
-    using A f_prof
+  have "\<forall> a \<in> A. a \<in> (reject m A p) \<or> a \<in> (reject n A p)"
+    using alt_set f_prof
     by blast
-  hence "S = reject x S p \<union> reject y S p"
+  hence "A = reject m A p \<union> reject n A p"
     using subsets
     by force
-  hence 1: "card ((reject x S p) \<union> (reject y S p)) = card S"
+  hence 1: "card ((reject m A p) \<union> (reject n A p)) = card A"
     by presburger
   from 0 1
-  show "card (reject (x \<parallel>\<^sub>\<up> y) S p) = n"
+  show "card (reject (m \<parallel>\<^sub>\<up> n) A p) = c"
     by simp
 qed
 
@@ -967,10 +1021,13 @@ text \<open>
 \<close>
 
 theorem par_comp_elim_one[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
-    defers_m_1: "defers 1 m" and
+    defers_m_one: "defers 1 m" and
     non_elec_m: "non_electing m" and
-    rejec_n_2: "rejects 2 n" and
+    rejec_n_two: "rejects 2 n" and
     disj_comp: "disjoint_compatibility m n"
   shows "eliminates 1 (m \<parallel>\<^sub>\<up> n)"
 proof (unfold eliminates_def, safe)
@@ -979,7 +1036,7 @@ proof (unfold eliminates_def, safe)
     unfolding non_electing_def
     by simp
   have electoral_mod_n: "electoral_module n"
-    using rejec_n_2
+    using rejec_n_two
     unfolding rejects_def
     by simp
   show "electoral_module (m \<parallel>\<^sub>\<up> n)"
@@ -990,24 +1047,23 @@ next
     A :: "'a set" and
     p :: "'a Profile"
   assume
-    min_2_card: "1 < card A" and
+    min_card_two: "1 < card A" and
     fin_A: "finite A" and
     prof_A: "profile A p"
-  have card_geq_1: "card A \<ge> 1"
-    using min_2_card dual_order.strict_trans2 less_imp_le_nat
+  have card_geq_one: "card A \<ge> 1"
+    using min_card_two dual_order.strict_trans2 less_imp_le_nat
     by blast
   have module: "electoral_module m"
     using non_elec_m
     unfolding non_electing_def
     by simp
-  have elec_card_0: "card (elect m A p) = 0"
+  have elec_card_zero: "card (elect m A p) = 0"
     using fin_A prof_A non_elec_m card_eq_0_iff
     unfolding non_electing_def
     by simp
-  moreover
-  from card_geq_1 have def_card_1:
-    "card (defer m A p) = 1"
-    using defers_m_1 module fin_A prof_A
+  moreover from card_geq_one
+  have def_card_one: "card (defer m A p) = 1"
+    using defers_m_one module fin_A prof_A
     unfolding defers_def
     by simp
   ultimately have card_reject_m:
@@ -1016,33 +1072,29 @@ next
     have "finite A"
       using fin_A
       by simp
-    moreover have
-      "well_formed A
-        (elect m A p, reject m A p, defer m A p)"
+    moreover have "well_formed A (elect m A p, reject m A p, defer m A p)"
       using fin_A prof_A module
       unfolding electoral_module_def
       by simp
     ultimately have
-      "card A =
-        card (elect m A p) + card (reject m A p) +
-          card (defer m A p)"
+      "card A = card (elect m A p) + card (reject m A p) + card (defer m A p)"
       using result_count
       by blast
     thus ?thesis
-      using def_card_1 elec_card_0
+      using def_card_one elec_card_zero
       by simp
   qed
-  have case1: "card A \<ge> 2"
-    using min_2_card
+  have case_1: "card A \<ge> 2"
+    using min_card_two
     by simp
-  from case1
+  from case_1
   have card_reject_n: "card (reject n A p) = 2"
-    using fin_A prof_A rejec_n_2
+    using fin_A prof_A rejec_n_two
     unfolding rejects_def
     by blast
   from card_reject_m card_reject_n
   have "card (reject m A p) + card (reject n A p) = card A + 1"
-    using card_geq_1
+    using card_geq_one
     by linarith
   with disj_comp prof_A fin_A card_reject_m card_reject_n
   show "card (reject (m \<parallel>\<^sub>\<up> n) A p) = 1"

--- a/theories/Compositional_Structures/Parallel_Composition.thy
+++ b/theories/Compositional_Structures/Parallel_Composition.thy
@@ -33,6 +33,10 @@ abbreviation parallel :: "'a Electoral_Module \<Rightarrow> 'a Aggregator \<Righ
 subsection \<open>Soundness\<close>
 
 theorem par_comp_sound[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    a :: "'a Aggregator"
   assumes
     mod_m: "electoral_module m" and
     mod_n: "electoral_module n" and
@@ -46,12 +50,12 @@ proof (unfold electoral_module_def, safe)
     fin_A: "finite A" and
     prof_A: "profile A p"
   have wf_quant:
-    "\<forall> a. aggregator a =
+    "\<forall> agg. aggregator agg =
       (\<forall> A' e r d e' r' d'.
         (\<not> well_formed (A'::'a set) (e, r', d) \<or>
           \<not> well_formed A' (r, d', e')) \<or>
         well_formed A'
-          (a A' (e, r', d) (r, d', e')))"
+          (agg A' (e, r', d) (r, d', e')))"
     unfolding aggregator_def
     by blast
   have wf_imp:
@@ -78,6 +82,10 @@ text \<open>
 \<close>
 
 theorem conserv_agg_presv_non_electing[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    a :: "'a Aggregator"
   assumes
     non_electing_m: "non_electing m" and
     non_electing_n: "non_electing n" and
@@ -103,11 +111,11 @@ next
   fix
     A :: "'a set" and
     p :: "'a Profile" and
-    x :: "'a"
+    w :: "'a"
   assume
     fin_A: "finite A" and
     prof_A: "profile A p" and
-    x_wins: "x \<in> elect (m \<parallel>\<^sub>a n) A p"
+    w_wins: "w \<in> elect (m \<parallel>\<^sub>a n) A p"
   have emod_m: "electoral_module m"
     using non_electing_m
     unfolding non_electing_def
@@ -128,13 +136,13 @@ next
                 defer_r (f A' (e', r', d') (e, r, d)) \<subseteq> d' \<union> d)"
     by linarith
   hence
-    "\<forall> a. agg_conservative a =
-      (aggregator a \<and>
+    "\<forall> agg. agg_conservative agg =
+      (aggregator agg \<and>
         (\<forall> A' e e' d d' r r'. (\<not> well_formed (A'::'a set) (e, r, d) \<or>
             \<not> well_formed A' (e', r', d')) \<or>
-          elect_r (a A' (e, r, d) (e', r', d')) \<subseteq> e \<union> e' \<and>
-            reject_r (a A' (e, r, d) (e', r', d')) \<subseteq> r \<union> r' \<and>
-            defer_r (a A' (e, r, d) (e', r', d')) \<subseteq> d \<union> d'))"
+          elect_r (agg A' (e, r, d) (e', r', d')) \<subseteq> e \<union> e' \<and>
+            reject_r (agg A' (e, r, d) (e', r', d')) \<subseteq> r \<union> r' \<and>
+            defer_r (agg A' (e, r, d) (e', r', d')) \<subseteq> d \<union> d'))"
     unfolding agg_conservative_def
     by simp
   hence
@@ -152,10 +160,10 @@ next
     using emod_m emod_n fin_A par_comp_result_sound
           prod.collapse prof_A
     by metis
-  hence "x \<in> ((elect m A p) \<union> (elect n A p))"
-    using x_wins
+  hence "w \<in> ((elect m A p) \<union> (elect n A p))"
+    using w_wins
     by auto
-  thus "x \<in> {}"
+  thus "w \<in> {}"
     using sup_bot_right fin_A prof_A
           non_electing_m non_electing_n
     unfolding non_electing_def

--- a/theories/Compositional_Structures/Revision_Composition.thy
+++ b/theories/Compositional_Structures/Revision_Composition.thy
@@ -29,6 +29,7 @@ abbreviation rev ::
 subsection \<open>Soundness\<close>
 
 theorem rev_comp_sound[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes "electoral_module m"
   shows "electoral_module (revision_composition m)"
 proof -
@@ -59,6 +60,7 @@ text \<open>
 \<close>
 
 theorem rev_comp_non_electing[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes "electoral_module m"
   shows "non_electing (m\<down>)"
   using assms
@@ -71,6 +73,7 @@ text \<open>
 \<close>
 
 theorem rev_comp_non_blocking[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes "electing m"
   shows "non_blocking (m\<down>)"
 proof (unfold non_blocking_def, safe, simp_all)
@@ -106,6 +109,7 @@ text \<open>
 \<close>
 
 theorem rev_comp_def_inv_mono[simp]:
+  fixes m :: "'a Electoral_Module"
   assumes "invariant_monotonicity m"
   shows "defer_invariant_monotonicity (m\<down>)"
 proof (unfold defer_invariant_monotonicity_def, safe)

--- a/theories/Compositional_Structures/Sequential_Composition.thy
+++ b/theories/Compositional_Structures/Sequential_Composition.thy
@@ -35,6 +35,11 @@ abbreviation sequence ::
   "m \<triangleright> n == sequential_composition m n"
 
 lemma seq_comp_presv_disj:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes module_m: "electoral_module m" and
           module_n: "electoral_module n" and
           f_prof:  "finite_profile A p"
@@ -101,7 +106,7 @@ proof -
       by moura
     then obtain sf2 :: "'a set \<Rightarrow> 'a set \<Rightarrow> 'a" where
       "\<forall> A B.
-        (A \<inter> B \<noteq> {} \<or> (\<forall>a. a \<notin> A \<or> (\<forall>b. b \<notin> B \<or> a \<noteq> b))) \<and>
+        (A \<inter> B \<noteq> {} \<or> (\<forall> a. a \<notin> A \<or> (\<forall> b. b \<notin> B \<or> a \<noteq> b))) \<and>
           (A \<inter> B = {} \<or> sf B A \<in> A \<and> sf2 B A \<in> B \<and>
             sf B A = sf2 B A)"
       by auto
@@ -262,6 +267,11 @@ proof -
 qed
 
 lemma seq_comp_presv_alts:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes module_m: "electoral_module m" and
           module_n: "electoral_module n" and
           f_prof:  "finite_profile A p"
@@ -309,6 +319,11 @@ qed
 subsection \<open>Soundness\<close>
 
 theorem seq_comp_sound[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n"
@@ -329,9 +344,14 @@ proof (unfold electoral_module_def, safe)
     by metis
 qed
 
-subsection \<open>Lemmata\<close>
+subsection \<open>Lemmas\<close>
 
 lemma seq_comp_dec_only_def:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
@@ -381,13 +401,18 @@ next
 qed
 
 lemma seq_comp_def_then_elect:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     n_electing_m: "non_electing m" and
     def_one_m: "defers 1 m" and
     electing_n: "electing n" and
     f_prof: "finite_profile A p"
   shows "elect (m \<triangleright> n) A p = defer m A p"
-proof cases
+proof (cases)
   assume "A = {}"
   with electing_n n_electing_m f_prof
   show ?thesis
@@ -426,7 +451,7 @@ next
   hence
     "\<exists> a \<in> A. elect (m \<triangleright> n) A p =
         elect n {a} (limit_profile {a} p)"
-    using prod.sel(1) prod.sel(2) sup_bot.left_neutral
+    using prod.sel(1, 2) sup_bot.left_neutral
     unfolding sequential_composition.simps
     by metis
   with def_card def electing_n n_electing_m f_prof
@@ -443,6 +468,11 @@ next
 qed
 
 lemma seq_comp_def_card_bounded:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
@@ -453,6 +483,11 @@ lemma seq_comp_def_card_bounded:
   by metis
 
 lemma seq_comp_def_set_bounded:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
@@ -463,6 +498,11 @@ lemma seq_comp_def_set_bounded:
   by metis
 
 lemma seq_comp_defers_def_set:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
@@ -475,6 +515,11 @@ lemma seq_comp_defers_def_set:
   by metis
 
 lemma seq_comp_def_then_elect_elec_set:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "electoral_module n" and
@@ -488,6 +533,11 @@ lemma seq_comp_def_then_elect_elec_set:
   by metis
 
 lemma seq_comp_elim_one_red_def_set:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     module_m: "electoral_module m" and
     module_n: "eliminates 1 n" and
@@ -500,6 +550,11 @@ lemma seq_comp_elim_one_red_def_set:
   by metis
 
 lemma seq_comp_def_set_sound:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile"
   assumes
     e_mod_m: "electoral_module m" and
     e_mod_n: "electoral_module n" and
@@ -514,6 +569,13 @@ proof (safe)
 qed
 
 lemma seq_comp_def_set_trans:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile" and
+    a :: "'a"
   assumes
     "a \<in> (defer (m \<triangleright> n) A p)" and
     "electoral_module m \<and> electoral_module n" and
@@ -530,6 +592,9 @@ text \<open>
 \<close>
 
 theorem seq_comp_presv_non_blocking[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     non_blocking_m: "non_blocking m" and
     non_blocking_n: "non_blocking n"
@@ -649,6 +714,9 @@ text \<open>
 \<close>
 
 theorem seq_comp_presv_non_electing[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     m_elect: "non_electing m" and
     n_elect: "non_electing n"
@@ -684,20 +752,20 @@ text \<open>
 \<close>
 
 theorem seq_comp_electing[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
-    def_one_m1:  "defers 1 m1" and
-    electing_m2: "electing m2"
-  shows "electing (m1 \<triangleright> m2)"
+    def_one_m:  "defers 1 m" and
+    electing_n: "electing n"
+  shows "electing (m \<triangleright> n)"
 proof -
-  have
-    "\<forall> A p. (card A \<ge> 1 \<and> finite_profile A p) \<longrightarrow>
-        card (defer m1 A p) = 1"
-    using def_one_m1
+  have "\<forall> A p. (card A \<ge> 1 \<and> finite_profile A p) \<longrightarrow> card (defer m A p) = 1"
+    using def_one_m
     unfolding defers_def
     by blast
   hence def_m1_not_empty:
-    "\<forall> A p. (A \<noteq> {} \<and> finite_profile A p) \<longrightarrow>
-        defer m1 A p \<noteq> {}"
+    "\<forall> A p. (A \<noteq> {} \<and> finite_profile A p) \<longrightarrow> defer m A p \<noteq> {}"
     using One_nat_def Suc_leI card_eq_0_iff
           card_gt_0_iff zero_neq_one
     by metis
@@ -711,27 +779,25 @@ proof -
       f_mod:
       "\<forall> f.
         (\<not> electing f \<or> electoral_module f \<and>
-          (\<forall> A prof.
-            (A \<noteq> {} \<and> finite A \<and> profile A prof) \<longrightarrow>
-              elect f A prof \<noteq> {})) \<and>
+          (\<forall> A prof. (A \<noteq> {} \<and> finite A \<and> profile A prof) \<longrightarrow> elect f A prof \<noteq> {})) \<and>
         (electing f \<or> \<not> electoral_module f \<or> f_set f \<noteq> {} \<and> finite (f_set f) \<and>
           profile (f_set f) (f_prof f) \<and> elect f (f_set f) (f_prof f) = {})"
       unfolding electing_def
       by moura
     hence f_elect:
-      "electoral_module m2 \<and>
-        (\<forall> A prof. (A \<noteq> {} \<and> finite A \<and> profile A prof) \<longrightarrow> elect m2 A prof \<noteq> {})"
-      using electing_m2
+      "electoral_module n \<and>
+        (\<forall> A prof. (A \<noteq> {} \<and> finite A \<and> profile A prof) \<longrightarrow> elect n A prof \<noteq> {})"
+      using electing_n
       by metis
     have def_card_one:
-      "electoral_module m1 \<and>
+      "electoral_module m \<and>
         (\<forall> A prof.
           (1 \<le> card A \<and> finite A \<and> profile A prof) \<longrightarrow>
-            card (defer m1 A prof) = 1)"
-      using def_one_m1
+            card (defer m A prof) = 1)"
+      using def_one_m
       unfolding defers_def
       by blast
-    hence "electoral_module (m1 \<triangleright> m2)"
+    hence "electoral_module (m \<triangleright> n)"
       using f_elect seq_comp_sound
       by metis
     with f_mod f_elect def_card_one
@@ -743,6 +809,13 @@ proof -
 qed
 
 lemma def_lift_inv_seq_comp_help:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module" and
+    A :: "'a set" and
+    p :: "'a Profile" and
+    q :: "'a Profile" and
+    a :: "'a"
   assumes
     monotone_m: "defer_lift_invariance m" and
     monotone_n: "defer_lift_invariance n" and
@@ -781,7 +854,7 @@ proof -
     by metis
   hence mono_n:
     "n ?new_Ap ?new_p = n ?new_Aq ?new_q"
-  proof cases
+  proof (cases)
     assume "lifted ?new_Ap ?new_p ?new_q a"
     thus ?thesis
       using defer_eq mono_m monotone_n def_and_lifted
@@ -852,6 +925,9 @@ text \<open>
 \<close>
 
 theorem seq_comp_presv_def_lift_inv[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     monotone_m: "defer_lift_invariance m" and
     monotone_n: "defer_lift_invariance n"
@@ -868,6 +944,9 @@ text \<open>
 \<close>
 
 theorem seq_comp_def_one[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     non_blocking_m: "non_blocking m" and
     non_electing_m: "non_electing m" and
@@ -954,13 +1033,17 @@ text \<open>
 \<close>
 
 theorem disj_compat_seq[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    m' :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     compatible: "disjoint_compatibility m n" and
-    module_m2: "electoral_module m2"
-  shows "disjoint_compatibility (m \<triangleright> m2) n"
+    module_m': "electoral_module m'"
+  shows "disjoint_compatibility (m \<triangleright> m') n"
 proof (unfold disjoint_compatibility_def, safe)
-  show "electoral_module (m \<triangleright> m2)"
-    using compatible module_m2 seq_comp_sound
+  show "electoral_module (m \<triangleright> m')"
+    using compatible module_m' seq_comp_sound
     unfolding disjoint_compatibility_def
     by metis
 next
@@ -972,8 +1055,8 @@ next
   fix S :: "'a set"
   assume fin_S: "finite S"
   have modules:
-    "electoral_module (m \<triangleright> m2) \<and> electoral_module n"
-    using compatible module_m2 seq_comp_sound
+    "electoral_module (m \<triangleright> m') \<and> electoral_module n"
+    using compatible module_m' seq_comp_sound
     unfolding disjoint_compatibility_def
     by metis
   obtain A where A:
@@ -987,15 +1070,15 @@ next
     by (metis (no_types, lifting))
   show
     "\<exists> A \<subseteq> S.
-      (\<forall> a \<in> A. indep_of_alt (m \<triangleright> m2) S a \<and>
-        (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject (m \<triangleright> m2) S p)) \<and>
+      (\<forall> a \<in> A. indep_of_alt (m \<triangleright> m') S a \<and>
+        (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject (m \<triangleright> m') S p)) \<and>
       (\<forall> a \<in> S - A. indep_of_alt n S a \<and>
         (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject n S p))"
   proof
     have
       "\<forall> a p q.
         a \<in> A \<and> equiv_prof_except_a S p q a \<longrightarrow>
-          (m \<triangleright> m2) S p = (m \<triangleright> m2) S q"
+          (m \<triangleright> m') S p = (m \<triangleright> m') S q"
     proof (safe)
       fix
         a :: "'a" and
@@ -1009,7 +1092,8 @@ next
         using A a b
         unfolding indep_of_alt_def
         by metis
-      from a b have profiles:
+      from a b
+      have profiles:
         "finite_profile S p \<and> finite_profile S q"
         unfolding equiv_prof_except_a_def
         by simp
@@ -1024,28 +1108,27 @@ next
               profiles negl_diff_imp_eq_limit_prof
         unfolding disjoint_compatibility_def eq_def
         by (metis (no_types, lifting))
-      with eq_def have
-        "m2 (defer m S p) (limit_profile (defer m S p) p) =
-          m2 (defer m S q) (limit_profile (defer m S q) q)"
+      with eq_def
+      have "m' (defer m S p) (limit_profile (defer m S p) p) =
+              m' (defer m S q) (limit_profile (defer m S q) q)"
         by simp
       moreover have "m S p = m S q"
         using A a b
         unfolding indep_of_alt_def
         by metis
-      ultimately show
-        "(m \<triangleright> m2) S p = (m \<triangleright> m2) S q"
+      ultimately show "(m \<triangleright> m') S p = (m \<triangleright> m') S q"
         unfolding sequential_composition.simps
         by (metis (full_types))
     qed
     moreover have
-      "\<forall> a \<in> A. \<forall> p. finite_profile S p \<longrightarrow> a \<in> reject (m \<triangleright> m2) S p"
+      "\<forall> a \<in> A. \<forall> p. finite_profile S p \<longrightarrow> a \<in> reject (m \<triangleright> m') S p"
       using A UnI1 prod.sel
       unfolding sequential_composition.simps
       by metis
     ultimately show
       "A \<subseteq> S \<and>
-        (\<forall> a \<in> A. indep_of_alt (m \<triangleright> m2) S a \<and>
-          (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject (m \<triangleright> m2) S p)) \<and>
+        (\<forall> a \<in> A. indep_of_alt (m \<triangleright> m') S a \<and>
+          (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject (m \<triangleright> m') S p)) \<and>
         (\<forall> a \<in> S - A. indep_of_alt n S a \<and>
           (\<forall> p. finite_profile S p \<longrightarrow> a \<in> reject n S p))"
       using A indep_of_alt_def modules
@@ -1061,6 +1144,9 @@ text \<open>
 \<close>
 
 theorem seq_comp_mono[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     def_monotone_m: "defer_lift_invariance m" and
     non_ele_m: "non_electing m" and
@@ -1107,6 +1193,9 @@ text \<open>
 \<close>
 
 theorem def_inv_mono_imp_def_lift_inv[simp]:
+  fixes
+    m :: "'a Electoral_Module" and
+    n :: "'a Electoral_Module"
   assumes
     strong_def_mon_m: "defer_invariant_monotonicity m" and
     non_electing_n: "non_electing n" and

--- a/theories/Copeland_Rule.thy
+++ b/theories/Copeland_Rule.thy
@@ -22,6 +22,13 @@ subsection \<open>Definition\<close>
 fun copeland_rule :: "'a Electoral_Module" where
   "copeland_rule A p = elector copeland A p"
 
+subsection \<open>Soundness\<close>
+
+theorem copeland_rule_sound: "electoral_module copeland_rule"
+  unfolding copeland_rule.simps
+  using elector_sound copeland_sound
+  by metis
+
 subsection \<open>Condorcet Consistency Property\<close>
 
 theorem copeland_condorcet: "condorcet_consistency copeland_rule"

--- a/theories/Minimax_Rule.thy
+++ b/theories/Minimax_Rule.thy
@@ -21,6 +21,13 @@ subsection \<open>Definition\<close>
 fun minimax_rule :: "'a Electoral_Module" where
   "minimax_rule A p = elector minimax A p"
 
+subsection \<open>Soundness\<close>
+
+theorem minimax_rule_sound: "electoral_module minimax_rule"
+  unfolding minimax_rule.simps
+  using elector_sound minimax_sound
+  by metis
+
 subsection \<open>Condorcet Consistency Property\<close>
 
 theorem minimax_condorcet: "condorcet_consistency minimax_rule"

--- a/theories/Nanson_Baldwin_Rule.thy
+++ b/theories/Nanson_Baldwin_Rule.thy
@@ -23,4 +23,10 @@ fun nanson_baldwin_rule :: "'a Electoral_Module" where
   "nanson_baldwin_rule A p =
     ((min_eliminator borda_score) \<circlearrowleft>\<^sub>\<exists>\<^sub>!\<^sub>d) A p"
 
+subsection \<open>Soundness\<close>
+
+theorem nanson_baldwin_rule_sound: "electoral_module nanson_baldwin_rule"
+  unfolding nanson_baldwin_rule.simps
+  by (simp add: loop_comp_sound)
+
 end

--- a/theories/Pairwise_Majority_Rule.thy
+++ b/theories/Pairwise_Majority_Rule.thy
@@ -29,6 +29,22 @@ fun condorcet' :: "'a Electoral_Module" where
 fun pairwise_majority_rule' :: "'a Electoral_Module" where
 "pairwise_majority_rule' A p = iterelect condorcet' A p"
 
+subsection \<open>Soundness\<close>
+
+theorem pairwise_majority_rule_sound: "electoral_module pairwise_majority_rule"
+  unfolding pairwise_majority_rule.simps
+  using condorcet_sound elector_sound
+  by metis
+
+theorem condorcet'_rule_sound: "electoral_module condorcet'"
+  unfolding condorcet'.simps
+  by (simp add: loop_comp_sound)
+
+theorem pairwise_majority_rule'_sound: "electoral_module pairwise_majority_rule'"
+  unfolding pairwise_majority_rule'.simps
+  using condorcet'_rule_sound elector_sound iter.simps iterelect.simps loop_comp_sound
+  by metis
+
 subsection \<open>Condorcet Consistency Property\<close>
 
 theorem condorcet_condorcet: "condorcet_consistency pairwise_majority_rule"

--- a/theories/ROOT
+++ b/theories/ROOT
@@ -18,17 +18,24 @@ session Verified_Voting_Rule_Construction = HOL +
   "
 options [browser_info, timeout = 300, document = pdf, document_output = "output"]
 
+sessions
+  "List-Index"
+
 directories
   "Compositional_Structures"
   "Compositional_Structures/Basic_Modules"
   "Compositional_Structures/Basic_Modules/Component_Types"
   "Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types"
+  "Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types"
 
 theories
 (* "Social-Choice Types" *)
   "Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Preference_Relation"
   "Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Result"
   "Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Profile"
+(* "Refined Data Types" *)
+  "Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Preference_List"
+  "Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Refined_Types/Profile_List"
 (* "Component Types" *)
   "Compositional_Structures/Basic_Modules/Component_Types/Electoral_Module"
   "Compositional_Structures/Basic_Modules/Component_Types/Evaluation_Function"

--- a/theories/Schwartz_Rule.thy
+++ b/theories/Schwartz_Rule.thy
@@ -24,4 +24,10 @@ fun schwartz_rule :: "'a Electoral_Module" where
   "schwartz_rule A p =
     ((less_average_eliminator borda_score) \<circlearrowleft>\<^sub>\<exists>\<^sub>!\<^sub>d) A p"
 
+subsection \<open>Soundness\<close>
+
+theorem schwartz_rule_sound: "electoral_module schwartz_rule"
+  unfolding schwartz_rule.simps
+  by (simp add: loop_comp_sound)
+
 end

--- a/theories/Sequential_Majority_Comparison.thy
+++ b/theories/Sequential_Majority_Comparison.thy
@@ -38,6 +38,7 @@ text \<open>
 \<close>
 
 theorem smc_sound:
+  fixes x :: "'a Preference_Relation"
   assumes order: "linear_order x"
   shows "electoral_module (smc x)"
 proof (unfold electoral_module_def, simp, safe, simp_all)
@@ -203,6 +204,7 @@ text \<open>
 \<close>
 
 theorem smc_electing:
+  fixes x :: "'a Preference_Relation"
   assumes "linear_order x"
   shows "electing (smc x)"
 proof -
@@ -288,6 +290,7 @@ text \<open>
 \<close>
 
 theorem smc_monotone:
+  fixes x :: "'a Preference_Relation"
   assumes "linear_order x"
   shows "monotonicity (smc x)"
 proof -


### PR DESCRIPTION
This branch introduces useful features for data Refinement.
The main contribution is the `Preference_List` theory that specifies a data type that represents ballots as lists and shows equivalence of some basic functions w.r.t the original ballot representation as order relation.
These `Preference_List`s are used in the `Profile_List` theory. For the profile property, only refinement is shown, rather than equivalence.

Feel free to ask any questions or make remarks to assumptions and modelling decisions.