### PR TITLE
Alternate definition of Condorcet consistency

### DIFF
--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Electoral_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Electoral_Module.thy
@@ -1153,6 +1153,55 @@ next
     by presburger
 qed
 
+lemma condorcet_consistency_3:
+  "condorcet_consistency m \<longleftrightarrow>
+      electoral_module m \<and>
+        (\<forall> A p w. condorcet_winner A p w \<longrightarrow>
+            (m A p =
+              ({w}, A - {w}, {})))"
+proof (safe)
+  assume "condorcet_consistency m"
+  thus "electoral_module m"
+    unfolding condorcet_consistency_def
+    by simp
+next
+  fix
+    A :: "'a set" and
+    p :: "'a Profile" and
+    w :: "'a"
+  assume
+    cc: "condorcet_consistency m" and
+    cwin: "condorcet_winner A p w"
+  show
+    "m A p = ({w}, A - {w}, {})"
+    using cond_winner_unique_3 cc cwin
+    unfolding condorcet_consistency_def
+    by (metis (mono_tags, lifting) fst_conv)
+next
+  assume
+    e_mod: "electoral_module m" and
+    cwin:
+    "\<forall> A p w. condorcet_winner A p w \<longrightarrow>
+      m A p = ({w}, A -  {w}, {})"
+  have
+    "\<forall> f. condorcet_consistency f =
+      (electoral_module f \<and>
+        (\<forall> A rs a. \<not> condorcet_winner A rs (a::'a) \<or>
+          f A rs = ({a \<in> A. condorcet_winner A rs a},
+                    A - elect f A rs, {})))"
+    unfolding condorcet_consistency_def
+    by blast
+  moreover have
+    "\<forall> A rs a. \<not> condorcet_winner A rs (a::'a) \<or>
+        {a \<in> A. condorcet_winner A rs a} = {a}"
+    using cond_winner_unique_3
+    by (metis (full_types))
+  ultimately show "condorcet_consistency m"
+    unfolding condorcet_consistency_def
+    using cond_winner_unique_3 e_mod cwin
+    by (metis (mono_tags, lifting) fst_conv)   
+qed
+
 subsubsection \<open>(Weak) Monotonicity\<close>
 
 text \<open>

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Electoral_Module.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Electoral_Module.thy
@@ -1153,6 +1153,37 @@ next
     by presburger
 qed
 
+lemma condorcet_consistency_3:
+  fixes m :: "'a Electoral_Module"
+  shows "condorcet_consistency m =
+           (electoral_module m \<and>
+              (\<forall> A p a. condorcet_winner A p a \<longrightarrow> (m A p = ({a}, A - {a}, {}))))"
+proof (simp only: condorcet_consistency_2, safe)
+  fix
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
+  assume
+    e_mod: "electoral_module m" and
+    cc: "\<forall> A p a'. condorcet_winner A p a' \<longrightarrow> m A p = ({a'}, A - elect m A p, {})" and
+    c_win: "condorcet_winner A p a"
+  show "m A p = ({a}, A - {a}, {})"
+    using cc c_win fst_conv
+    by (metis (mono_tags, lifting))
+next
+  fix
+    A :: "'a set" and
+    p :: "'a Profile" and
+    a :: "'a"
+  assume
+    e_mod: "electoral_module m" and
+    cc: "\<forall> A p a'. condorcet_winner A p a' \<longrightarrow> m A p = ({a'}, A -  {a'}, {})" and
+    c_win: "condorcet_winner A p a"
+  show "m A p = ({a}, A -  elect m A p, {})"
+    using cc c_win fst_conv
+    by (metis (mono_tags, lifting))
+qed
+
 subsubsection \<open>(Weak) Monotonicity\<close>
 
 text \<open>

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Preference_Relation.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Preference_Relation.thy
@@ -33,6 +33,10 @@ fun is_less_preferred_than ::
   "'a \<Rightarrow> 'a Preference_Relation \<Rightarrow> 'a \<Rightarrow> bool" ("_ \<preceq>\<^sub>_ _" [50, 1000, 51] 50) where
     "a \<preceq>\<^sub>r b = ((a, b) \<in> r)"
 
+fun alts_\<V> :: "'a Vote \<Rightarrow> 'a set" where "alts_\<V> V = fst V"
+
+fun pref_\<V> :: "'a Vote \<Rightarrow> 'a Preference_Relation" where "pref_\<V> V = snd V"
+
 lemma lin_imp_antisym:
   fixes
     A :: "'a set" and

--- a/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Profile.thy
+++ b/theories/Compositional_Structures/Basic_Modules/Component_Types/Social_Choice_Types/Profile.thy
@@ -32,6 +32,10 @@ type_synonym 'a Profile = "('a Preference_Relation) list"
 
 type_synonym 'a Election = "'a set \<times> 'a Profile"
 
+fun alts_\<E> :: "'a Election \<Rightarrow> 'a set" where "alts_\<E> E = fst E"
+
+fun prof_\<E> :: "'a Election \<Rightarrow> 'a Profile" where "prof_\<E> E = snd E"
+
 text \<open>
   A profile on a finite set of alternatives A contains only ballots that are
   linear orders on A.

--- a/theories/Compositional_Structures/Loop_Composition.thy
+++ b/theories/Compositional_Structures/Loop_Composition.thy
@@ -444,7 +444,7 @@ proof (induct n arbitrary: acc rule: less_induct)
             loop_comp_helper acc m t A p = loop_comp_helper (acc \<triangleright> m) m t A p"
       proof (safe)
         assume emod_acc: "electoral_module acc"
-        have emod_implies_defer_subset:
+        have sound_imp_defer_subset:
           "electoral_module m \<longrightarrow> defer (acc \<triangleright> m) A p \<subseteq> defer acc A p"
           using emod_acc f_prof seq_comp_def_set_bounded
           by blast
@@ -456,7 +456,7 @@ proof (induct n arbitrary: acc rule: less_induct)
           using def_presv_fin_prof emod_acc f_prof
           by metis
         have "defer (acc \<triangleright> m) A p \<subseteq> defer acc A p"
-          using emod_implies_defer_subset defer_lift_invariance_def monotone_m
+          using sound_imp_defer_subset defer_lift_invariance_def monotone_m
           by blast
         hence "defer (acc \<triangleright> m) A p \<subset> defer acc A p"
           using fin_def_limited_acc card_ineq card_psubset


### PR DESCRIPTION
The last merge was perfect, thank you! My only suggestion is to add yet another alternative definition of Condorcet consistency. I find it understandable, especially when proving the property for a specific electoral module. It can be transferred to the Imperative HOL refinement of an electoral module. Imho, the first example is somewhat more expressive than the second, but this is, of course, debatable.
![Screenshot from 2023-07-04 22-11-19](https://github.com/VeriVote/verifiedVotingRuleConstruction/assets/15802245/f5bb73bf-9b30-4cfa-946f-ee46b5b4705e)
![Screenshot from 2023-07-04 22-11-50](https://github.com/VeriVote/verifiedVotingRuleConstruction/assets/15802245/04396f4d-d687-438b-9c2a-34ba41b169f0)
